### PR TITLE
fix(#4) :: LXC 환경 AppArmor 비활성화

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,6 +2,8 @@ services:
   mysql:
     image: mysql:8.0
     container_name: app-db
+    security_opt:
+      - apparmor:unconfined
     env_file:
       - .env
     volumes:
@@ -18,6 +20,8 @@ services:
   blue:
     image: ${IMAGE}
     container_name: app-blue
+    security_opt:
+      - apparmor:unconfined
     ports:
       - "8090:8080"
     env_file:
@@ -38,6 +42,8 @@ services:
   green:
     image: ${IMAGE}
     container_name: app-green
+    security_opt:
+      - apparmor:unconfined
     ports:
       - "8091:8080"
     env_file:


### PR DESCRIPTION
## 🎫 관련 이슈

close #4

<br>

## 📄 개요

Proxmox LXC 내 Docker 실행 시 AppArmor 프로필 로드 권한 문제를 해결했습니다.

<br>

## 🔨 작업 내용

- 전체 서비스(mysql, blue, green)에 `security_opt: apparmor:unconfined` 적용
- LXC 레벨에서 이미 격리되어 있으므로 보안상 문제없음

<br>

## 🏁 확인 사항

- [x] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?