### PR TITLE
fix(#8): 배포 워크플로우 sudo 의존성 제거

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -111,6 +111,8 @@ jobs:
           SSHPASS="$NGINX_SSH_PASSWORD" sshpass -e ssh -o StrictHostKeyChecking=no \
             -p ${{ secrets.NGINX_SSH_PORT }} \
             ${{ secrets.NGINX_SSH_USER }}@${{ secrets.NGINX_SSH_HOST }} \
-            "sudo sed -i 's|proxy_pass http://${APP_HOST}:[0-9]*;|proxy_pass http://${APP_HOST}:${ACTIVE_PORT};|' ${NGINX_CONF} && sudo nginx -s reload"
+            "if command -v sudo >/dev/null 2>&1; then SUDO='sudo'; else SUDO=''; fi; \
+            \$SUDO sed -i 's|proxy_pass http://${APP_HOST}:[0-9]*;|proxy_pass http://${APP_HOST}:${ACTIVE_PORT};|' ${NGINX_CONF} && \
+            \$SUDO nginx -s reload"
 
           echo "Nginx 전환 완료: ${APP_HOST}:${ACTIVE_PORT}"


### PR DESCRIPTION
## Summary
- Nginx 포트 전환 단계에서 원격 서버에 `sudo`가 없을 때도 동작하도록 수정했습니다.
- 원격 호스트에서 `sudo` 존재 여부를 확인한 뒤 `sed`와 `nginx -s reload`를 실행하도록 변경했습니다.

## Test Plan
- [x] workflow 스크립트 변경부 점검
- [x] git diff --check .github/workflows/cd.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 배포 워크플로우 개선으로 원격 SSH 명령 실행 시 `sudo` 가용성에 따른 조건부 처리 추가. 셸 이스케이핑 조정으로 원격 호스트에서 안정적으로 평가되도록 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->