### PR TITLE
feat: 사용자 이름 수정 API 추가

### DIFF
--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/AuthExceptionHandler.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/AuthExceptionHandler.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestControllerAdvice(assignableTypes = AuthController.class)
+@RestControllerAdvice(assignableTypes = {AuthController.class, UserController.class})
 public class AuthExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/UserController.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/UserController.java
@@ -1,0 +1,32 @@
+package bssm.plantshuman.peopleandgreen.auth.adapter.in.web;
+
+import bssm.plantshuman.peopleandgreen.auth.adapter.in.web.dto.request.UpdateUsernameRequest;
+import bssm.plantshuman.peopleandgreen.auth.adapter.in.web.dto.response.AuthTokenResponse;
+import bssm.plantshuman.peopleandgreen.auth.adapter.out.security.AuthenticatedUser;
+import bssm.plantshuman.peopleandgreen.auth.application.port.in.UpdateUsernameUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UpdateUsernameUseCase updateUsernameUseCase;
+
+    @PatchMapping("/me/username")
+    public ResponseEntity<AuthTokenResponse.UserResponse> updateUsername(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @Valid @RequestBody UpdateUsernameRequest request
+    ) {
+        return ResponseEntity.ok(AuthTokenResponse.UserResponse.from(
+                updateUsernameUseCase.updateUsername(authenticatedUser.userId(), request.username())
+        ));
+    }
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/dto/request/UpdateUsernameRequest.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/dto/request/UpdateUsernameRequest.java
@@ -1,8 +1,11 @@
 package bssm.plantshuman.peopleandgreen.auth.adapter.in.web.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record UpdateUsernameRequest(
-        @NotBlank String username
+        @NotBlank
+        @Size(max = 30)
+        String username
 ) {
 }

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/dto/request/UpdateUsernameRequest.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/dto/request/UpdateUsernameRequest.java
@@ -1,0 +1,8 @@
+package bssm.plantshuman.peopleandgreen.auth.adapter.in.web.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateUsernameRequest(
+        @NotBlank String username
+) {
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/dto/response/AuthTokenResponse.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/dto/response/AuthTokenResponse.java
@@ -28,7 +28,7 @@ public record AuthTokenResponse(
             String name,
             String profileImageUrl
     ) {
-        static UserResponse from(AppUser user) {
+        public static UserResponse from(AppUser user) {
             return new UserResponse(user.id(), user.email(), user.name(), user.profileImageUrl());
         }
     }

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/UserPersistenceAdapter.java
@@ -25,7 +25,7 @@ public class UserPersistenceAdapter implements UserAccountPort {
     public AppUser upsertGoogleUser(GoogleUserInfo userInfo) {
         AppUserEntity entity = appUserRepository.findByOauthProviderAndOauthProviderUserId(OAuthProvider.GOOGLE, userInfo.providerUserId())
                 .map(existing -> {
-                    existing.updateProfile(userInfo.email(), userInfo.name(), userInfo.profileImageUrl());
+                    existing.updateGoogleProfile(userInfo.email(), userInfo.profileImageUrl());
                     return existing;
                 })
                 .orElseGet(() -> new AppUserEntity(
@@ -42,6 +42,15 @@ public class UserPersistenceAdapter implements UserAccountPort {
     @Override
     public Optional<AppUser> findById(Long userId) {
         return appUserRepository.findById(userId).map(this::toDomain);
+    }
+
+    @Override
+    @Transactional
+    public AppUser updateUsername(Long userId, String username) {
+        AppUserEntity entity = appUserRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        entity.updateUsername(username);
+        return toDomain(entity);
     }
 
     public AppUserEntity getReference(Long userId) {

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/entity/AppUserEntity.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/entity/AppUserEntity.java
@@ -57,9 +57,12 @@ public class AppUserEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
-    public void updateProfile(String email, String name, String profileImageUrl) {
+    public void updateGoogleProfile(String email, String profileImageUrl) {
         this.email = email;
-        this.name = name;
         this.profileImageUrl = profileImageUrl;
+    }
+
+    public void updateUsername(String name) {
+        this.name = name;
     }
 }

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/application/port/in/UpdateUsernameUseCase.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/application/port/in/UpdateUsernameUseCase.java
@@ -1,0 +1,8 @@
+package bssm.plantshuman.peopleandgreen.auth.application.port.in;
+
+import bssm.plantshuman.peopleandgreen.auth.domain.model.AppUser;
+
+public interface UpdateUsernameUseCase {
+
+    AppUser updateUsername(Long userId, String username);
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/application/port/out/UserAccountPort.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/application/port/out/UserAccountPort.java
@@ -10,4 +10,6 @@ public interface UserAccountPort {
     AppUser upsertGoogleUser(GoogleUserInfo userInfo);
 
     Optional<AppUser> findById(Long userId);
+
+    AppUser updateUsername(Long userId, String username);
 }

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/application/service/UpdateUsernameService.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/application/service/UpdateUsernameService.java
@@ -10,8 +10,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UpdateUsernameService implements UpdateUsernameUseCase {
 
-    private static final int MAX_USERNAME_LENGTH = 30;
-
     private final UserAccountPort userAccountPort;
 
     @Override
@@ -28,9 +26,6 @@ public class UpdateUsernameService implements UpdateUsernameUseCase {
         String normalized = username.trim();
         if (normalized.isEmpty()) {
             throw new IllegalArgumentException("Username must not be blank");
-        }
-        if (normalized.length() > MAX_USERNAME_LENGTH) {
-            throw new IllegalArgumentException("Username must be at most 30 characters");
         }
         return normalized;
     }

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/application/service/UpdateUsernameService.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/application/service/UpdateUsernameService.java
@@ -1,0 +1,37 @@
+package bssm.plantshuman.peopleandgreen.auth.application.service;
+
+import bssm.plantshuman.peopleandgreen.auth.application.port.in.UpdateUsernameUseCase;
+import bssm.plantshuman.peopleandgreen.auth.application.port.out.UserAccountPort;
+import bssm.plantshuman.peopleandgreen.auth.domain.model.AppUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateUsernameService implements UpdateUsernameUseCase {
+
+    private static final int MAX_USERNAME_LENGTH = 30;
+
+    private final UserAccountPort userAccountPort;
+
+    @Override
+    public AppUser updateUsername(Long userId, String username) {
+        String normalizedUsername = normalize(username);
+        return userAccountPort.updateUsername(userId, normalizedUsername);
+    }
+
+    private String normalize(String username) {
+        if (username == null) {
+            throw new IllegalArgumentException("Username is required");
+        }
+
+        String normalized = username.trim();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException("Username must not be blank");
+        }
+        if (normalized.length() > MAX_USERNAME_LENGTH) {
+            throw new IllegalArgumentException("Username must be at most 30 characters");
+        }
+        return normalized;
+    }
+}

--- a/src/test/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/UserControllerTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/UserControllerTest.java
@@ -1,0 +1,44 @@
+package bssm.plantshuman.peopleandgreen.auth.adapter.in.web;
+
+import bssm.plantshuman.peopleandgreen.auth.adapter.in.web.dto.request.UpdateUsernameRequest;
+import bssm.plantshuman.peopleandgreen.auth.adapter.in.web.dto.response.AuthTokenResponse;
+import bssm.plantshuman.peopleandgreen.auth.adapter.out.security.AuthenticatedUser;
+import bssm.plantshuman.peopleandgreen.auth.application.port.in.UpdateUsernameUseCase;
+import bssm.plantshuman.peopleandgreen.auth.domain.model.AppUser;
+import bssm.plantshuman.peopleandgreen.auth.domain.model.OAuthProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UserControllerTest {
+
+    @Test
+    void updatesUsernameForAuthenticatedUser() {
+        RecordingUpdateUsernameUseCase useCase = new RecordingUpdateUsernameUseCase();
+        UserController controller = new UserController(useCase);
+
+        ResponseEntity<AuthTokenResponse.UserResponse> response = controller.updateUsername(
+                new AuthenticatedUser(1L),
+                new UpdateUsernameRequest("UserName")
+        );
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(1L, useCase.userId);
+        assertEquals("UserName", useCase.username);
+        assertEquals("UserName", response.getBody().name());
+    }
+
+    private static final class RecordingUpdateUsernameUseCase implements UpdateUsernameUseCase {
+
+        private Long userId;
+        private String username;
+
+        @Override
+        public AppUser updateUsername(Long userId, String username) {
+            this.userId = userId;
+            this.username = username;
+            return new AppUser(userId, OAuthProvider.GOOGLE, "google-123", "jjm@example.com", username, "https://image");
+        }
+    }
+}

--- a/src/test/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/dto/request/UpdateUsernameRequestTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/dto/request/UpdateUsernameRequestTest.java
@@ -1,0 +1,19 @@
+package bssm.plantshuman.peopleandgreen.auth.adapter.in.web.dto.request;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UpdateUsernameRequestTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void rejectsUsernameLongerThanThirtyCharacters() {
+        UpdateUsernameRequest request = new UpdateUsernameRequest("1234567890123456789012345678901");
+
+        assertEquals(1, validator.validate(request).size());
+    }
+}

--- a/src/test/java/bssm/plantshuman/peopleandgreen/auth/application/service/AuthServiceTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/auth/application/service/AuthServiceTest.java
@@ -165,13 +165,6 @@ class AuthServiceTest {
         assertThrows(IllegalArgumentException.class, () -> service.updateUsername(1L, "   "));
     }
 
-    @Test
-    void rejectsTooLongUsername() {
-        UpdateUsernameService service = new UpdateUsernameService(new RecordingUserAccountPort());
-
-        assertThrows(IllegalArgumentException.class, () -> service.updateUsername(1L, "1234567890123456789012345678901"));
-    }
-
     private static final class StubIssueJwtPort implements IssueJwtPort {
 
         @Override

--- a/src/test/java/bssm/plantshuman/peopleandgreen/auth/application/service/AuthServiceTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/auth/application/service/AuthServiceTest.java
@@ -69,6 +69,27 @@ class AuthServiceTest {
     }
 
     @Test
+    void keepsExistingUsernameWhenGoogleUserLogsInAgain() {
+        RecordingUserAccountPort userAccountPort = new RecordingUserAccountPort(
+                new AppUser(1L, OAuthProvider.GOOGLE, "google-123", "before@example.com", "chosenName", "https://old-image")
+        );
+        LoginWithGoogleService service = new LoginWithGoogleService(
+                GOOGLE_PROPERTIES,
+                (code, redirectUri) -> new GoogleUserInfo("google-123", "after@example.com", "googleName", "https://new-image"),
+                userAccountPort,
+                new StubIssueJwtPort(),
+                new RecordingRefreshTokenStorePort(),
+                HASH_PORT
+        );
+
+        var tokens = service.login("AUTH_CODE", "STATE_TOKEN", "http://localhost:3000/auth/google/callback");
+
+        assertEquals("chosenName", tokens.user().name());
+        assertEquals("after@example.com", tokens.user().email());
+        assertEquals("https://new-image", tokens.user().profileImageUrl());
+    }
+
+    @Test
     void rejectsLoginWhenRedirectUriIsNotAllowed() {
         LoginWithGoogleService service = new LoginWithGoogleService(
                 GOOGLE_PROPERTIES,
@@ -126,6 +147,29 @@ class AuthServiceTest {
         service.logout("ACCESS_TOKEN");
 
         assertEquals(null, refreshTokenStorePort.revokedTokenId);
+    }
+
+    @Test
+    void updatesUsernameForExistingUser() {
+        UpdateUsernameService service = new UpdateUsernameService(new RecordingUserAccountPort());
+
+        AppUser user = service.updateUsername(1L, "  UserName  ");
+
+        assertEquals("UserName", user.name());
+    }
+
+    @Test
+    void rejectsBlankUsername() {
+        UpdateUsernameService service = new UpdateUsernameService(new RecordingUserAccountPort());
+
+        assertThrows(IllegalArgumentException.class, () -> service.updateUsername(1L, "   "));
+    }
+
+    @Test
+    void rejectsTooLongUsername() {
+        UpdateUsernameService service = new UpdateUsernameService(new RecordingUserAccountPort());
+
+        assertThrows(IllegalArgumentException.class, () -> service.updateUsername(1L, "1234567890123456789012345678901"));
     }
 
     private static final class StubIssueJwtPort implements IssueJwtPort {
@@ -225,6 +269,55 @@ class AuthServiceTest {
         @Override
         public Optional<AppUser> findById(Long userId) {
             return Optional.of(new AppUser(userId, OAuthProvider.GOOGLE, "google-123", "jjm@example.com", "jjm", "https://image"));
+        }
+
+        @Override
+        public AppUser updateUsername(Long userId, String username) {
+            return new AppUser(userId, OAuthProvider.GOOGLE, "google-123", "jjm@example.com", username, "https://image");
+        }
+    }
+
+    private static final class RecordingUserAccountPort implements UserAccountPort {
+
+        private AppUser existingUser;
+
+        private RecordingUserAccountPort() {
+            this(new AppUser(1L, OAuthProvider.GOOGLE, "google-123", "jjm@example.com", "jjm", "https://image"));
+        }
+
+        private RecordingUserAccountPort(AppUser existingUser) {
+            this.existingUser = existingUser;
+        }
+
+        @Override
+        public AppUser upsertGoogleUser(GoogleUserInfo userInfo) {
+            if (existingUser != null
+                    && existingUser.oauthProvider() == OAuthProvider.GOOGLE
+                    && existingUser.oauthProviderUserId().equals(userInfo.providerUserId())) {
+                existingUser = new AppUser(
+                        existingUser.id(),
+                        existingUser.oauthProvider(),
+                        existingUser.oauthProviderUserId(),
+                        userInfo.email(),
+                        existingUser.name(),
+                        userInfo.profileImageUrl()
+                );
+                return existingUser;
+            }
+
+            existingUser = new AppUser(1L, OAuthProvider.GOOGLE, userInfo.providerUserId(), userInfo.email(), userInfo.name(), userInfo.profileImageUrl());
+            return existingUser;
+        }
+
+        @Override
+        public Optional<AppUser> findById(Long userId) {
+            return Optional.ofNullable(existingUser).filter(user -> user.id().equals(userId));
+        }
+
+        @Override
+        public AppUser updateUsername(Long userId, String username) {
+            existingUser = new AppUser(userId, OAuthProvider.GOOGLE, "google-123", "jjm@example.com", username, "https://image");
+            return existingUser;
         }
     }
 


### PR DESCRIPTION
## 변경 사항
- 구글 재로그인 시 사용자가 수정한 이름이 유지되도록 변경
- `PATCH /users/me/username` API 추가
- username 공백/길이 검증 및 관련 테스트 추가

## 테스트
- `./gradlew test --tests 'bssm.plantshuman.peopleandgreen.auth.*' --tests 'bssm.plantshuman.peopleandgreen.auth.**.*'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인증된 사용자가 자신의 사용자명(최대 30자)을 업데이트할 수 있는 API가 추가되었습니다.
  * 입력값은 앞뒤 공백이 제거되며, 공백만으로 된 사용자명은 허용되지 않습니다.
  * 업데이트된 사용자 정보가 성공 응답으로 반환됩니다.

* **테스트**
  * 사용자명 업데이트와 관련된 단위/통합 테스트들이 추가되어 검증 커버리지가 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->