### PR TITLE
fix: ensure production deploy always uses latest built image

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           images: ${{ steps.image.outputs.name }}
           tags: |
-            type=sha
+            type=sha,format=long
             type=raw,value=latest
 
       - name: GHCR 로그인
@@ -66,7 +66,7 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           password: ${{ secrets.SSH_PASSWORD }}
           port: ${{ secrets.SSH_PORT }}
-          envs: IMAGE,CR_TOKEN,CR_USER,DB_ROOT_PASSWORD,DB_DATABASE,DB_USERNAME,DB_PASSWORD,AUTH_JWT_SECRET,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI
+          envs: IMAGE,DEPLOY_IMAGE,CR_TOKEN,CR_USER,DB_ROOT_PASSWORD,DB_DATABASE,DB_USERNAME,DB_PASSWORD,AUTH_JWT_SECRET,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI
           script: |
             cat > ~/app/.env << EOF
             MYSQL_ROOT_PASSWORD=$DB_ROOT_PASSWORD
@@ -87,9 +87,10 @@ jobs:
             echo "$CR_TOKEN" | docker login ghcr.io -u "$CR_USER" --password-stdin
             mv ~/app/scripts/deploy.sh ~/app/deploy.sh 2>/dev/null || true
             chmod +x ~/app/deploy.sh
-            ~/app/deploy.sh "$IMAGE:latest"
+            ~/app/deploy.sh "$DEPLOY_IMAGE"
         env:
           IMAGE: ${{ steps.image.outputs.name }}
+          DEPLOY_IMAGE: ${{ steps.image.outputs.name }}:sha-${{ github.sha }}
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CR_USER: ${{ github.actor }}
           DB_ROOT_PASSWORD: ${{ secrets.DB_ROOT_PASSWORD }}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,6 +14,9 @@ fi
 cd ~/app
 export IMAGE
 
+echo ">>> 이미지 pull: $IMAGE"
+docker pull "$IMAGE"
+
 # 초기 배포 (아무 컨테이너도 없을 때)
 if ! docker ps --format '{{.Names}}' | grep -q 'app-'; then
   echo ">>> 초기 배포: blue (포트 $BLUE_PORT)"


### PR DESCRIPTION
## What
- Pin deploy target image to commit-specific SHA tag (`sha-${GITHUB_SHA}`) instead of `latest`
- Force image refresh on the server via `docker pull` before compose rollout

## Why
Production was able to keep using a stale local `latest` image, causing runtime behavior to differ from merged code.

## Changes
- `.github/workflows/cd.yml`
  - metadata tag format changed to long SHA
  - deploy step now passes `DEPLOY_IMAGE=ghcr.io/...:sha-${GITHUB_SHA}`
- `scripts/deploy.sh`
  - added `docker pull "$IMAGE"` before blue/green deployment

## Validation
- `bash -n scripts/deploy.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 배포 파이프라인의 Docker 이미지 태깅 형식이 개선되었습니다.
* 배포 스크립트에 이미지 풀 단계가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->