### PR TITLE
fix(cd): enable swagger docs in production env

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,7 +66,7 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           password: ${{ secrets.SSH_PASSWORD }}
           port: ${{ secrets.SSH_PORT }}
-          envs: IMAGE,DEPLOY_IMAGE,CR_TOKEN,CR_USER,DB_ROOT_PASSWORD,DB_DATABASE,DB_USERNAME,DB_PASSWORD,AUTH_JWT_SECRET,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI
+          envs: IMAGE,DEPLOY_IMAGE,CR_TOKEN,CR_USER,DB_ROOT_PASSWORD,DB_DATABASE,DB_USERNAME,DB_PASSWORD,AUTH_JWT_SECRET,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,SPRINGDOC_ENABLED
           script: |
             cat > ~/app/.env << EOF
             MYSQL_ROOT_PASSWORD=$DB_ROOT_PASSWORD
@@ -82,6 +82,7 @@ jobs:
             GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID
             GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
             GOOGLE_REDIRECT_URI=$GOOGLE_REDIRECT_URI
+            SPRINGDOC_ENABLED=${SPRINGDOC_ENABLED:-true}
             EOF
             chmod 600 ~/app/.env
             echo "$CR_TOKEN" | docker login ghcr.io -u "$CR_USER" --password-stdin
@@ -101,6 +102,7 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
+          SPRINGDOC_ENABLED: ${{ secrets.SPRINGDOC_ENABLED }}
 
       - name: sshpass 설치
         run: sudo apt-get update && sudo apt-get install -y sshpass


### PR DESCRIPTION
## What
- Add `SPRINGDOC_ENABLED` to production `.env` generation in CD
- Default it to `true` when the secret is not set (`${SPRINGDOC_ENABLED:-true}`)

## Why
After the previous deploy fix, `/swagger-ui.html` returned `404` because Swagger was disabled by default in `application.yml` (`SPRINGDOC_ENABLED=false` fallback) and CD did not set the variable.

## Validation
- Confirmed config path in app: `/swagger-ui.html`
- Verified CD now writes `SPRINGDOC_ENABLED` into `~/app/.env`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* 배포 워크플로우에 SpringDoc 문서화 기능 제어를 위한 환경 변수 구성 추가
* 변수가 설정되지 않은 경우 기본적으로 활성화되도록 설정
* 원격 배포 단계에서 환경 변수를 전달하는 워크플로우 연결 구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->