### PR TITLE
fix(cd): enable swagger docs in production env

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,7 +66,7 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           password: ${{ secrets.SSH_PASSWORD }}
           port: ${{ secrets.SSH_PORT }}
-          envs: IMAGE,DEPLOY_IMAGE,CR_TOKEN,CR_USER,DB_ROOT_PASSWORD,DB_DATABASE,DB_USERNAME,DB_PASSWORD,AUTH_JWT_SECRET,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI
+          envs: IMAGE,DEPLOY_IMAGE,CR_TOKEN,CR_USER,DB_ROOT_PASSWORD,DB_DATABASE,DB_USERNAME,DB_PASSWORD,AUTH_JWT_SECRET,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,SPRINGDOC_ENABLED
           script: |
             cat > ~/app/.env << EOF
             MYSQL_ROOT_PASSWORD=$DB_ROOT_PASSWORD
@@ -82,6 +82,7 @@ jobs:
             GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID
             GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
             GOOGLE_REDIRECT_URI=$GOOGLE_REDIRECT_URI
+            SPRINGDOC_ENABLED=${SPRINGDOC_ENABLED:-true}
             EOF
             chmod 600 ~/app/.env
             echo "$CR_TOKEN" | docker login ghcr.io -u "$CR_USER" --password-stdin
@@ -101,6 +102,7 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
+          SPRINGDOC_ENABLED: ${{ secrets.SPRINGDOC_ENABLED }}
 
       - name: sshpass 설치
         run: sudo apt-get update && sudo apt-get install -y sshpass


### PR DESCRIPTION
## What
- Add `SPRINGDOC_ENABLED` to production `.env` generation in CD
- Default to `true` when secret is absent (`${SPRINGDOC_ENABLED:-true}`)

## Why
`/swagger-ui.html` returned 404 in production because springdoc was disabled by default and CD did not set this variable.

## Validation
- Confirmed swagger path config is `/swagger-ui.html`
- CD now writes `SPRINGDOC_ENABLED` into `~/app/.env`
