### PR TITLE
feat: add recommendation history

### DIFF
--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/adapter/in/web/PlantRecommendationController.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/adapter/in/web/PlantRecommendationController.java
@@ -1,11 +1,13 @@
 package bssm.plantshuman.peopleandgreen.recommendation.adapter.in.web;
 
+import bssm.plantshuman.peopleandgreen.auth.adapter.out.security.AuthenticatedUser;
 import bssm.plantshuman.peopleandgreen.recommendation.adapter.in.web.dto.request.RecommendPlantsRequest;
 import bssm.plantshuman.peopleandgreen.recommendation.adapter.in.web.dto.response.RecommendPlantsResponse;
-import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.RecommendPlantsUseCase;
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.RecommendPlantsWithHistoryUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,10 +18,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/diagnosis/recommendations")
 public class PlantRecommendationController {
 
-    private final RecommendPlantsUseCase recommendPlantsUseCase;
+    private final RecommendPlantsWithHistoryUseCase recommendPlantsWithHistoryUseCase;
 
     @PostMapping
-    public ResponseEntity<RecommendPlantsResponse> recommend(@Valid @RequestBody RecommendPlantsRequest request) {
-        return ResponseEntity.ok(RecommendPlantsResponse.from(recommendPlantsUseCase.recommend(request.toCommand())));
+    public ResponseEntity<RecommendPlantsResponse> recommend(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @Valid @RequestBody RecommendPlantsRequest request
+    ) {
+        var executionResult = recommendPlantsWithHistoryUseCase.recommend(authenticatedUser.userId(), request.toCommand());
+        return ResponseEntity.ok(RecommendPlantsResponse.from(
+                executionResult.historyId(),
+                executionResult.saved(),
+                executionResult.result()
+        ));
     }
 }

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/adapter/in/web/dto/response/RecommendPlantsResponse.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/adapter/in/web/dto/response/RecommendPlantsResponse.java
@@ -5,13 +5,17 @@ import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlan
 import java.util.List;
 
 public record RecommendPlantsResponse(
+        Long historyId,
+        boolean saved,
         String representativeEnvironment,
         List<String> secondaryEnvironmentTags,
         List<PlantRecommendationResponse> plants
 ) {
 
-    public static RecommendPlantsResponse from(RecommendPlantsResult result) {
+    public static RecommendPlantsResponse from(Long historyId, boolean saved, RecommendPlantsResult result) {
         return new RecommendPlantsResponse(
+                historyId,
+                saved,
                 result.representativeEnvironment().name(),
                 result.secondaryEnvironmentTags().stream().map(Enum::name).toList(),
                 result.plants().stream().map(PlantRecommendationResponse::from).toList()

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/port/in/DeleteRecommendationHistoryUseCase.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/port/in/DeleteRecommendationHistoryUseCase.java
@@ -1,0 +1,6 @@
+package bssm.plantshuman.peopleandgreen.recommendation.application.port.in;
+
+public interface DeleteRecommendationHistoryUseCase {
+
+    void delete(Long userId, Long historyId);
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/port/in/GetRecommendationHistoriesUseCase.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/port/in/GetRecommendationHistoriesUseCase.java
@@ -4,5 +4,5 @@ import bssm.plantshuman.peopleandgreen.recommendation.domain.model.Recommendatio
 
 public interface GetRecommendationHistoriesUseCase {
 
-    RecommendationHistoryCursorPage getHistories(Long userId, String cursor, int size);
+    RecommendationHistoryCursorPage getHistories(Long userId, Long cursor, int size);
 }

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/port/in/GetRecommendationHistoriesUseCase.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/port/in/GetRecommendationHistoriesUseCase.java
@@ -1,0 +1,8 @@
+package bssm.plantshuman.peopleandgreen.recommendation.application.port.in;
+
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistoryCursorPage;
+
+public interface GetRecommendationHistoriesUseCase {
+
+    RecommendationHistoryCursorPage getHistories(Long userId, String cursor, int size);
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/port/in/GetRecommendationHistoryUseCase.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/port/in/GetRecommendationHistoryUseCase.java
@@ -1,0 +1,8 @@
+package bssm.plantshuman.peopleandgreen.recommendation.application.port.in;
+
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistory;
+
+public interface GetRecommendationHistoryUseCase {
+
+    RecommendationHistory getHistory(Long userId, Long historyId);
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/port/in/RecommendPlantsWithHistoryUseCase.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/port/in/RecommendPlantsWithHistoryUseCase.java
@@ -1,0 +1,9 @@
+package bssm.plantshuman.peopleandgreen.recommendation.application.port.in;
+
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsCommand;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsExecutionResult;
+
+public interface RecommendPlantsWithHistoryUseCase {
+
+    RecommendPlantsExecutionResult recommend(Long userId, RecommendPlantsCommand command);
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/port/out/RecommendationHistoryCommandPort.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/port/out/RecommendationHistoryCommandPort.java
@@ -1,0 +1,10 @@
+package bssm.plantshuman.peopleandgreen.recommendation.application.port.out;
+
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistoryDraft;
+
+public interface RecommendationHistoryCommandPort {
+
+    Long save(RecommendationHistoryDraft draft);
+
+    void delete(Long userId, Long historyId);
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/port/out/RecommendationHistoryQueryPort.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/port/out/RecommendationHistoryQueryPort.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 public interface RecommendationHistoryQueryPort {
 
-    RecommendationHistoryCursorPage getHistories(Long userId, String cursor, int size);
+    RecommendationHistoryCursorPage getHistories(Long userId, Long cursor, int size);
 
     Optional<RecommendationHistory> getHistory(Long userId, Long historyId);
 }

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/port/out/RecommendationHistoryQueryPort.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/port/out/RecommendationHistoryQueryPort.java
@@ -1,0 +1,13 @@
+package bssm.plantshuman.peopleandgreen.recommendation.application.port.out;
+
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistory;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistoryCursorPage;
+
+import java.util.Optional;
+
+public interface RecommendationHistoryQueryPort {
+
+    RecommendationHistoryCursorPage getHistories(Long userId, String cursor, int size);
+
+    Optional<RecommendationHistory> getHistory(Long userId, Long historyId);
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/DeleteRecommendationHistoryService.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/DeleteRecommendationHistoryService.java
@@ -1,0 +1,18 @@
+package bssm.plantshuman.peopleandgreen.recommendation.application.service;
+
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.DeleteRecommendationHistoryUseCase;
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.out.RecommendationHistoryCommandPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteRecommendationHistoryService implements DeleteRecommendationHistoryUseCase {
+
+    private final RecommendationHistoryCommandPort recommendationHistoryCommandPort;
+
+    @Override
+    public void delete(Long userId, Long historyId) {
+        recommendationHistoryCommandPort.delete(userId, historyId);
+    }
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/GetRecommendationHistoriesService.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/GetRecommendationHistoriesService.java
@@ -1,0 +1,19 @@
+package bssm.plantshuman.peopleandgreen.recommendation.application.service;
+
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.GetRecommendationHistoriesUseCase;
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.out.RecommendationHistoryQueryPort;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistoryCursorPage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetRecommendationHistoriesService implements GetRecommendationHistoriesUseCase {
+
+    private final RecommendationHistoryQueryPort recommendationHistoryQueryPort;
+
+    @Override
+    public RecommendationHistoryCursorPage getHistories(Long userId, String cursor, int size) {
+        return recommendationHistoryQueryPort.getHistories(userId, cursor, size);
+    }
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/GetRecommendationHistoriesService.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/GetRecommendationHistoriesService.java
@@ -13,7 +13,7 @@ public class GetRecommendationHistoriesService implements GetRecommendationHisto
     private final RecommendationHistoryQueryPort recommendationHistoryQueryPort;
 
     @Override
-    public RecommendationHistoryCursorPage getHistories(Long userId, String cursor, int size) {
+    public RecommendationHistoryCursorPage getHistories(Long userId, Long cursor, int size) {
         return recommendationHistoryQueryPort.getHistories(userId, cursor, size);
     }
 }

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/GetRecommendationHistoryService.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/GetRecommendationHistoryService.java
@@ -1,0 +1,21 @@
+package bssm.plantshuman.peopleandgreen.recommendation.application.service;
+
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.GetRecommendationHistoryUseCase;
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.out.RecommendationHistoryQueryPort;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.exception.RecommendationHistoryNotFoundException;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetRecommendationHistoryService implements GetRecommendationHistoryUseCase {
+
+    private final RecommendationHistoryQueryPort recommendationHistoryQueryPort;
+
+    @Override
+    public RecommendationHistory getHistory(Long userId, Long historyId) {
+        return recommendationHistoryQueryPort.getHistory(userId, historyId)
+                .orElseThrow(RecommendationHistoryNotFoundException::new);
+    }
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/RecommendPlantsWithHistoryService.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/RecommendPlantsWithHistoryService.java
@@ -1,0 +1,58 @@
+package bssm.plantshuman.peopleandgreen.recommendation.application.service;
+
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.RecommendPlantsUseCase;
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.RecommendPlantsWithHistoryUseCase;
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.out.RecommendationHistoryCommandPort;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.EnvironmentType;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsCommand;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsExecutionResult;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsResult;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistoryDraft;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendPlantsWithHistoryService implements RecommendPlantsWithHistoryUseCase {
+
+    private final RecommendPlantsUseCase recommendPlantsUseCase;
+    private final RecommendationHistoryCommandPort recommendationHistoryCommandPort;
+
+    @Override
+    public RecommendPlantsExecutionResult recommend(Long userId, RecommendPlantsCommand command) {
+        RecommendPlantsResult result = recommendPlantsUseCase.recommend(command);
+        RecommendationHistoryDraft draft = new RecommendationHistoryDraft(
+                userId,
+                titleFor(result.representativeEnvironment()),
+                summarizePlants(result),
+                command,
+                result
+        );
+        Long historyId = recommendationHistoryCommandPort.save(draft);
+        return new RecommendPlantsExecutionResult(historyId, true, result);
+    }
+
+    private String summarizePlants(RecommendPlantsResult result) {
+        return result.plants().stream()
+                .limit(3)
+                .map(plant -> plant.plantName())
+                .toList()
+                .stream()
+                .reduce((first, second) -> first + ", " + second)
+                .orElse("");
+    }
+
+    private String titleFor(EnvironmentType environmentType) {
+        return switch (environmentType) {
+            case ENV_01_SUNNY -> "햇빛이 잘드는 공간";
+            case ENV_02_DARK -> "빛이 적은 공간";
+            case ENV_03_BRIGHT_INDIRECT -> "은은한 빛이 드는 공간";
+            case ENV_04_HOT -> "따뜻한 공간";
+            case ENV_05_COLD -> "서늘한 공간";
+            case ENV_06_DRY -> "건조한 공간";
+            case ENV_07_HUMID -> "습한 공간";
+            case ENV_08_WELL_VENTILATED -> "환기가 잘되는 공간";
+            case ENV_09_CLOSED -> "바람이 적은 공간";
+        };
+    }
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/exception/RecommendationHistoryNotFoundException.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/exception/RecommendationHistoryNotFoundException.java
@@ -1,0 +1,11 @@
+package bssm.plantshuman.peopleandgreen.recommendation.domain.exception;
+
+import bssm.plantshuman.peopleandgreen.recommendation.domain.exception.error.RecommendationHistoryErrorProperty;
+import bssm.plantshuman.peopleandgreen.shared.error.PeopleAndGreenException;
+
+public class RecommendationHistoryNotFoundException extends PeopleAndGreenException {
+
+    public RecommendationHistoryNotFoundException() {
+        super(RecommendationHistoryErrorProperty.RECOMMENDATION_HISTORY_NOT_FOUND);
+    }
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/exception/error/RecommendationHistoryErrorProperty.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/exception/error/RecommendationHistoryErrorProperty.java
@@ -1,0 +1,16 @@
+package bssm.plantshuman.peopleandgreen.recommendation.domain.exception.error;
+
+import bssm.plantshuman.peopleandgreen.shared.error.ErrorProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum RecommendationHistoryErrorProperty implements ErrorProperty {
+
+    RECOMMENDATION_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "Recommendation history not found");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/model/RecommendPlantsExecutionResult.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/model/RecommendPlantsExecutionResult.java
@@ -1,0 +1,8 @@
+package bssm.plantshuman.peopleandgreen.recommendation.domain.model;
+
+public record RecommendPlantsExecutionResult(
+        Long historyId,
+        boolean saved,
+        RecommendPlantsResult result
+) {
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/model/RecommendationHistory.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/model/RecommendationHistory.java
@@ -1,0 +1,14 @@
+package bssm.plantshuman.peopleandgreen.recommendation.domain.model;
+
+import java.time.Instant;
+
+public record RecommendationHistory(
+        Long id,
+        Long userId,
+        String title,
+        String plantSummaryText,
+        RecommendPlantsCommand requestSnapshot,
+        RecommendPlantsResult resultSnapshot,
+        Instant createdAt
+) {
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/model/RecommendationHistoryCursorPage.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/model/RecommendationHistoryCursorPage.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public record RecommendationHistoryCursorPage(
         List<RecommendationHistorySummary> items,
-        String nextCursor,
+        Long nextCursor,
         boolean hasNext
 ) {
 

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/model/RecommendationHistoryCursorPage.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/model/RecommendationHistoryCursorPage.java
@@ -1,0 +1,14 @@
+package bssm.plantshuman.peopleandgreen.recommendation.domain.model;
+
+import java.util.List;
+
+public record RecommendationHistoryCursorPage(
+        List<RecommendationHistorySummary> items,
+        String nextCursor,
+        boolean hasNext
+) {
+
+    public RecommendationHistoryCursorPage {
+        items = List.copyOf(items);
+    }
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/model/RecommendationHistoryDraft.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/model/RecommendationHistoryDraft.java
@@ -1,0 +1,10 @@
+package bssm.plantshuman.peopleandgreen.recommendation.domain.model;
+
+public record RecommendationHistoryDraft(
+        Long userId,
+        String title,
+        String plantSummaryText,
+        RecommendPlantsCommand requestSnapshot,
+        RecommendPlantsResult resultSnapshot
+) {
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/model/RecommendationHistorySummary.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/model/RecommendationHistorySummary.java
@@ -1,0 +1,11 @@
+package bssm.plantshuman.peopleandgreen.recommendation.domain.model;
+
+import java.time.Instant;
+
+public record RecommendationHistorySummary(
+        Long historyId,
+        String title,
+        String plantSummaryText,
+        Instant createdAt
+) {
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/in/web/RecommendationHistoryController.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/in/web/RecommendationHistoryController.java
@@ -1,0 +1,59 @@
+package bssm.plantshuman.peopleandgreen.recommendationhistory.adapter.in.web;
+
+import bssm.plantshuman.peopleandgreen.auth.adapter.out.security.AuthenticatedUser;
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.DeleteRecommendationHistoryUseCase;
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.GetRecommendationHistoriesUseCase;
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.GetRecommendationHistoryUseCase;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@RequiredArgsConstructor
+@RequestMapping("/users/me/recommendation-histories")
+public class RecommendationHistoryController {
+
+    private final GetRecommendationHistoriesUseCase getRecommendationHistoriesUseCase;
+    private final GetRecommendationHistoryUseCase getRecommendationHistoryUseCase;
+    private final DeleteRecommendationHistoryUseCase deleteRecommendationHistoryUseCase;
+
+    @GetMapping
+    public ResponseEntity<RecommendationHistoryPageResponse> getHistories(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
+    ) {
+        return ResponseEntity.ok(RecommendationHistoryPageResponse.from(
+                getRecommendationHistoriesUseCase.getHistories(authenticatedUser.userId(), cursor, size)
+        ));
+    }
+
+    @GetMapping("/{historyId}")
+    public ResponseEntity<RecommendationHistoryDetailResponse> getHistory(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @PathVariable Long historyId
+    ) {
+        return ResponseEntity.ok(RecommendationHistoryDetailResponse.from(
+                getRecommendationHistoryUseCase.getHistory(authenticatedUser.userId(), historyId)
+        ));
+    }
+
+    @DeleteMapping("/{historyId}")
+    public ResponseEntity<Void> deleteHistory(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @PathVariable Long historyId
+    ) {
+        deleteRecommendationHistoryUseCase.delete(authenticatedUser.userId(), historyId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/in/web/RecommendationHistoryController.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/in/web/RecommendationHistoryController.java
@@ -30,7 +30,7 @@ public class RecommendationHistoryController {
     @GetMapping
     public ResponseEntity<RecommendationHistoryPageResponse> getHistories(
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
-            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false) Long cursor,
             @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
     ) {
         return ResponseEntity.ok(RecommendationHistoryPageResponse.from(

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/in/web/RecommendationHistoryDetailResponse.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/in/web/RecommendationHistoryDetailResponse.java
@@ -1,0 +1,68 @@
+package bssm.plantshuman.peopleandgreen.recommendationhistory.adapter.in.web;
+
+import bssm.plantshuman.peopleandgreen.recommendation.adapter.in.web.dto.response.PlantRecommendationResponse;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsCommand;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsResult;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistory;
+
+import java.time.Instant;
+import java.util.List;
+
+public record RecommendationHistoryDetailResponse(
+        Long historyId,
+        String title,
+        String plantSummaryText,
+        Instant createdAt,
+        RequestSnapshot request,
+        ResultSnapshot result
+) {
+
+    public static RecommendationHistoryDetailResponse from(RecommendationHistory history) {
+        return new RecommendationHistoryDetailResponse(
+                history.id(),
+                history.title(),
+                history.plantSummaryText(),
+                history.createdAt(),
+                RequestSnapshot.from(history.requestSnapshot()),
+                ResultSnapshot.from(history.resultSnapshot())
+        );
+    }
+
+    public record RequestSnapshot(
+            String sunlight,
+            String ventilation,
+            String temperature,
+            String humidity,
+            String careLevel,
+            String experienceLevel,
+            boolean hasPet,
+            String placement
+    ) {
+        static RequestSnapshot from(RecommendPlantsCommand command) {
+            return new RequestSnapshot(
+                    command.sunlight().name(),
+                    command.ventilation().name(),
+                    command.temperature().name(),
+                    command.humidity().name(),
+                    command.careLevel().name(),
+                    command.experienceLevel().name(),
+                    command.hasPet(),
+                    command.placement().name()
+            );
+        }
+    }
+
+    public record ResultSnapshot(
+            String representativeEnvironment,
+            List<String> secondaryEnvironmentTags,
+            List<PlantRecommendationResponse> plants
+    ) {
+        static ResultSnapshot from(RecommendPlantsResult result) {
+            return new ResultSnapshot(
+                    result.representativeEnvironment().name(),
+                    result.secondaryEnvironmentTags().stream().map(Enum::name).toList(),
+                    result.plants().stream().map(PlantRecommendationResponse::from).toList()
+            );
+        }
+    }
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/in/web/RecommendationHistoryPageResponse.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/in/web/RecommendationHistoryPageResponse.java
@@ -1,0 +1,34 @@
+package bssm.plantshuman.peopleandgreen.recommendationhistory.adapter.in.web;
+
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistoryCursorPage;
+
+import java.time.Instant;
+import java.util.List;
+
+public record RecommendationHistoryPageResponse(
+        List<Item> items,
+        String nextCursor,
+        boolean hasNext
+) {
+
+    public static RecommendationHistoryPageResponse from(RecommendationHistoryCursorPage page) {
+        return new RecommendationHistoryPageResponse(
+                page.items().stream().map(item -> new Item(
+                        item.historyId(),
+                        item.title(),
+                        item.plantSummaryText(),
+                        item.createdAt()
+                )).toList(),
+                page.nextCursor(),
+                page.hasNext()
+        );
+    }
+
+    public record Item(
+            Long historyId,
+            String title,
+            String plantSummaryText,
+            Instant createdAt
+    ) {
+    }
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/in/web/RecommendationHistoryPageResponse.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/in/web/RecommendationHistoryPageResponse.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public record RecommendationHistoryPageResponse(
         List<Item> items,
-        String nextCursor,
+        Long nextCursor,
         boolean hasNext
 ) {
 

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/out/persistence/RecommendationHistoryPersistenceAdapter.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/out/persistence/RecommendationHistoryPersistenceAdapter.java
@@ -1,0 +1,106 @@
+package bssm.plantshuman.peopleandgreen.recommendationhistory.adapter.out.persistence;
+
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.out.RecommendationHistoryCommandPort;
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.out.RecommendationHistoryQueryPort;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.exception.RecommendationHistoryNotFoundException;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsCommand;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsResult;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistory;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistoryCursorPage;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistoryDraft;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistorySummary;
+import bssm.plantshuman.peopleandgreen.recommendationhistory.adapter.out.persistence.entity.RecommendationHistoryEntity;
+import bssm.plantshuman.peopleandgreen.recommendationhistory.adapter.out.persistence.repository.RecommendationHistoryRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class RecommendationHistoryPersistenceAdapter implements RecommendationHistoryCommandPort, RecommendationHistoryQueryPort {
+
+    private final RecommendationHistoryRepository recommendationHistoryRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    @Transactional
+    public Long save(RecommendationHistoryDraft draft) {
+        RecommendationHistoryEntity saved = recommendationHistoryRepository.save(new RecommendationHistoryEntity(
+                draft.userId(),
+                draft.title(),
+                draft.plantSummaryText(),
+                writeJson(draft.requestSnapshot()),
+                writeJson(draft.resultSnapshot()),
+                Instant.now()
+        ));
+        return saved.getId();
+    }
+
+    @Override
+    public RecommendationHistoryCursorPage getHistories(Long userId, String cursor, int size) {
+        List<RecommendationHistoryEntity> entities = cursor == null
+                ? recommendationHistoryRepository.findByUserIdOrderByIdDesc(userId, PageRequest.of(0, size + 1))
+                : recommendationHistoryRepository.findByUserIdAndIdLessThanOrderByIdDesc(userId, Long.parseLong(cursor), PageRequest.of(0, size + 1));
+
+        boolean hasNext = entities.size() > size;
+        List<RecommendationHistorySummary> items = entities.stream()
+                .limit(size)
+                .map(entity -> new RecommendationHistorySummary(
+                        entity.getId(),
+                        entity.getTitle(),
+                        entity.getPlantSummaryText(),
+                        entity.getCreatedAt()
+                ))
+                .toList();
+        String nextCursor = hasNext ? String.valueOf(items.getLast().historyId()) : null;
+        return new RecommendationHistoryCursorPage(items, nextCursor, hasNext);
+    }
+
+    @Override
+    public Optional<RecommendationHistory> getHistory(Long userId, Long historyId) {
+        return recommendationHistoryRepository.findByIdAndUserId(historyId, userId).map(this::toDomain);
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long userId, Long historyId) {
+        if (recommendationHistoryRepository.deleteOwnedHistory(userId, historyId) == 0) {
+            throw new RecommendationHistoryNotFoundException();
+        }
+    }
+
+    private RecommendationHistory toDomain(RecommendationHistoryEntity entity) {
+        return new RecommendationHistory(
+                entity.getId(),
+                entity.getUserId(),
+                entity.getTitle(),
+                entity.getPlantSummaryText(),
+                readJson(entity.getRequestSnapshot(), RecommendPlantsCommand.class),
+                readJson(entity.getResultSnapshot(), RecommendPlantsResult.class),
+                entity.getCreatedAt()
+        );
+    }
+
+    private String writeJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("Failed to serialize recommendation history", exception);
+        }
+    }
+
+    private <T> T readJson(String value, Class<T> type) {
+        try {
+            return objectMapper.readValue(value, type);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("Failed to deserialize recommendation history", exception);
+        }
+    }
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/out/persistence/RecommendationHistoryPersistenceAdapter.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/out/persistence/RecommendationHistoryPersistenceAdapter.java
@@ -44,10 +44,10 @@ public class RecommendationHistoryPersistenceAdapter implements RecommendationHi
     }
 
     @Override
-    public RecommendationHistoryCursorPage getHistories(Long userId, String cursor, int size) {
+    public RecommendationHistoryCursorPage getHistories(Long userId, Long cursor, int size) {
         List<RecommendationHistoryEntity> entities = cursor == null
                 ? recommendationHistoryRepository.findByUserIdOrderByIdDesc(userId, PageRequest.of(0, size + 1))
-                : recommendationHistoryRepository.findByUserIdAndIdLessThanOrderByIdDesc(userId, Long.parseLong(cursor), PageRequest.of(0, size + 1));
+                : recommendationHistoryRepository.findByUserIdAndIdLessThanOrderByIdDesc(userId, cursor, PageRequest.of(0, size + 1));
 
         boolean hasNext = entities.size() > size;
         List<RecommendationHistorySummary> items = entities.stream()
@@ -59,7 +59,7 @@ public class RecommendationHistoryPersistenceAdapter implements RecommendationHi
                         entity.getCreatedAt()
                 ))
                 .toList();
-        String nextCursor = hasNext ? String.valueOf(items.getLast().historyId()) : null;
+        Long nextCursor = hasNext ? items.getLast().historyId() : null;
         return new RecommendationHistoryCursorPage(items, nextCursor, hasNext);
     }
 

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/out/persistence/entity/RecommendationHistoryEntity.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/out/persistence/entity/RecommendationHistoryEntity.java
@@ -1,0 +1,61 @@
+package bssm.plantshuman.peopleandgreen.recommendationhistory.adapter.out.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "recommendation_history")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecommendationHistoryEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "plant_summary_text", nullable = false, length = 255)
+    private String plantSummaryText;
+
+    @Lob
+    @Column(name = "request_snapshot", nullable = false, columnDefinition = "TEXT")
+    private String requestSnapshot;
+
+    @Lob
+    @Column(name = "result_snapshot", nullable = false, columnDefinition = "TEXT")
+    private String resultSnapshot;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    public RecommendationHistoryEntity(
+            Long userId,
+            String title,
+            String plantSummaryText,
+            String requestSnapshot,
+            String resultSnapshot,
+            Instant createdAt
+    ) {
+        this.userId = userId;
+        this.title = title;
+        this.plantSummaryText = plantSummaryText;
+        this.requestSnapshot = requestSnapshot;
+        this.resultSnapshot = resultSnapshot;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/out/persistence/repository/RecommendationHistoryRepository.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/out/persistence/repository/RecommendationHistoryRepository.java
@@ -1,0 +1,24 @@
+package bssm.plantshuman.peopleandgreen.recommendationhistory.adapter.out.persistence.repository;
+
+import bssm.plantshuman.peopleandgreen.recommendationhistory.adapter.out.persistence.entity.RecommendationHistoryEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RecommendationHistoryRepository extends JpaRepository<RecommendationHistoryEntity, Long> {
+
+    List<RecommendationHistoryEntity> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);
+
+    List<RecommendationHistoryEntity> findByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long cursor, Pageable pageable);
+
+    Optional<RecommendationHistoryEntity> findByIdAndUserId(Long historyId, Long userId);
+
+    @Modifying
+    @Query("delete from RecommendationHistoryEntity h where h.id = :historyId and h.userId = :userId")
+    int deleteOwnedHistory(@Param("userId") Long userId, @Param("historyId") Long historyId);
+}

--- a/src/main/resources/db/migration/V2__create_recommendation_history_table.sql
+++ b/src/main/resources/db/migration/V2__create_recommendation_history_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS recommendation_history (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    title VARCHAR(100) NOT NULL,
+    plant_summary_text VARCHAR(255) NOT NULL,
+    request_snapshot TEXT NOT NULL,
+    result_snapshot TEXT NOT NULL,
+    created_at DATETIME(6) NOT NULL
+);
+
+CREATE INDEX idx_recommendation_history_user_id_id
+    ON recommendation_history (user_id, id DESC);

--- a/src/test/java/bssm/plantshuman/peopleandgreen/recommendation/adapter/in/web/PlantRecommendationControllerTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/recommendation/adapter/in/web/PlantRecommendationControllerTest.java
@@ -1,8 +1,9 @@
 package bssm.plantshuman.peopleandgreen.recommendation.adapter.in.web;
 
+import bssm.plantshuman.peopleandgreen.auth.adapter.out.security.AuthenticatedUser;
 import bssm.plantshuman.peopleandgreen.recommendation.adapter.in.web.dto.request.RecommendPlantsRequest;
 import bssm.plantshuman.peopleandgreen.recommendation.adapter.in.web.dto.response.RecommendPlantsResponse;
-import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.RecommendPlantsUseCase;
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.RecommendPlantsWithHistoryUseCase;
 import bssm.plantshuman.peopleandgreen.recommendation.domain.model.AirPurificationLevel;
 import bssm.plantshuman.peopleandgreen.recommendation.domain.model.CareLevel;
 import bssm.plantshuman.peopleandgreen.recommendation.domain.model.DifficultyLevel;
@@ -13,6 +14,7 @@ import bssm.plantshuman.peopleandgreen.recommendation.domain.model.PetSafetyLeve
 import bssm.plantshuman.peopleandgreen.recommendation.domain.model.PlacementType;
 import bssm.plantshuman.peopleandgreen.recommendation.domain.model.PlantRecommendation;
 import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsCommand;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsExecutionResult;
 import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsResult;
 import bssm.plantshuman.peopleandgreen.recommendation.domain.model.SizeCategory;
 import bssm.plantshuman.peopleandgreen.recommendation.domain.model.SunlightLevel;
@@ -30,7 +32,7 @@ class PlantRecommendationControllerTest {
 
     @Test
     void mapsUseCaseResultToResponseBody() {
-        RecommendPlantsUseCase useCase = new StubRecommendPlantsUseCase();
+        RecommendPlantsWithHistoryUseCase useCase = new StubRecommendPlantsUseCase();
         PlantRecommendationController controller = new PlantRecommendationController(useCase);
 
         RecommendPlantsRequest request = new RecommendPlantsRequest(
@@ -44,9 +46,11 @@ class PlantRecommendationControllerTest {
                 PlacementType.BATHROOM
         );
 
-        ResponseEntity<RecommendPlantsResponse> response = controller.recommend(request);
+        ResponseEntity<RecommendPlantsResponse> response = controller.recommend(new AuthenticatedUser(1L), request);
 
         assertEquals(200, response.getStatusCode().value());
+        assertEquals(23L, response.getBody().historyId());
+        assertEquals(true, response.getBody().saved());
         assertEquals("ENV_07_HUMID", response.getBody().representativeEnvironment());
         assertEquals("PLT-023", response.getBody().plants().getFirst().plantId());
         assertEquals(88, response.getBody().plants().getFirst().score());
@@ -54,7 +58,7 @@ class PlantRecommendationControllerTest {
 
     @Test
     void rejectsRequestWhenRequiredFieldIsMissing() {
-        RecommendPlantsUseCase useCase = new StubRecommendPlantsUseCase();
+        RecommendPlantsWithHistoryUseCase useCase = new StubRecommendPlantsUseCase();
         PlantRecommendationController controller = new PlantRecommendationController(useCase);
 
         RecommendPlantsRequest request = new RecommendPlantsRequest(
@@ -68,12 +72,12 @@ class PlantRecommendationControllerTest {
                 PlacementType.BATHROOM
         );
 
-        assertThrows(IllegalArgumentException.class, () -> controller.recommend(request));
+        assertThrows(IllegalArgumentException.class, () -> controller.recommend(new AuthenticatedUser(1L), request));
     }
 
     @Test
     void rejectsRequestWhenHasPetIsMissing() {
-        RecommendPlantsUseCase useCase = new StubRecommendPlantsUseCase();
+        RecommendPlantsWithHistoryUseCase useCase = new StubRecommendPlantsUseCase();
         PlantRecommendationController controller = new PlantRecommendationController(useCase);
 
         RecommendPlantsRequest request = new RecommendPlantsRequest(
@@ -87,14 +91,17 @@ class PlantRecommendationControllerTest {
                 PlacementType.BATHROOM
         );
 
-        assertThrows(IllegalArgumentException.class, () -> controller.recommend(request));
+        assertThrows(IllegalArgumentException.class, () -> controller.recommend(new AuthenticatedUser(1L), request));
     }
 
-    private static final class StubRecommendPlantsUseCase implements RecommendPlantsUseCase {
+    private static final class StubRecommendPlantsUseCase implements RecommendPlantsWithHistoryUseCase {
 
         @Override
-        public RecommendPlantsResult recommend(RecommendPlantsCommand command) {
-            return new RecommendPlantsResult(
+        public RecommendPlantsExecutionResult recommend(Long userId, RecommendPlantsCommand command) {
+            return new RecommendPlantsExecutionResult(
+                    23L,
+                    true,
+                    new RecommendPlantsResult(
                     EnvironmentType.ENV_07_HUMID,
                     List.of(EnvironmentType.ENV_03_BRIGHT_INDIRECT),
                     List.of(new PlantRecommendation(
@@ -113,6 +120,7 @@ class PlantRecommendationControllerTest {
                             List.of(PlacementType.BATHROOM, PlacementType.KITCHEN),
                             "습한 공간에 잘 적응하는 식물"
                     ))
+                    )
             );
         }
     }

--- a/src/test/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/RecommendPlantsWithHistoryServiceTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/RecommendPlantsWithHistoryServiceTest.java
@@ -1,0 +1,101 @@
+package bssm.plantshuman.peopleandgreen.recommendation.application.service;
+
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.RecommendPlantsUseCase;
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.out.RecommendationHistoryCommandPort;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.AirPurificationLevel;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.DifficultyLevel;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.EnvironmentType;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.PetSafetyLevel;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.PlacementType;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.PlantRecommendation;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsCommand;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsExecutionResult;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsResult;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistoryDraft;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.SizeCategory;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RecommendPlantsWithHistoryServiceTest {
+
+    @Test
+    void savesRecommendationHistoryAfterRecommendation() {
+        RecordingRecommendationHistoryCommandPort historyCommandPort = new RecordingRecommendationHistoryCommandPort();
+        RecommendPlantsWithHistoryService service = new RecommendPlantsWithHistoryService(
+                command -> result(),
+                historyCommandPort
+        );
+
+        RecommendPlantsExecutionResult executionResult = service.recommend(1L, command());
+
+        assertEquals(1L, historyCommandPort.savedDraft.userId());
+        assertEquals("햇빛이 잘드는 공간", historyCommandPort.savedDraft.title());
+        assertEquals("스투키, 몬스테라, 산세베리아", historyCommandPort.savedDraft.plantSummaryText());
+        assertEquals(55L, executionResult.historyId());
+        assertEquals(true, executionResult.saved());
+        assertEquals("스투키", executionResult.result().plants().getFirst().plantName());
+    }
+
+    private RecommendPlantsCommand command() {
+        return new RecommendPlantsCommand(
+                bssm.plantshuman.peopleandgreen.recommendation.domain.model.SunlightLevel.HIGH,
+                bssm.plantshuman.peopleandgreen.recommendation.domain.model.VentilationLevel.NORMAL,
+                bssm.plantshuman.peopleandgreen.recommendation.domain.model.TemperatureBand.NORMAL,
+                bssm.plantshuman.peopleandgreen.recommendation.domain.model.HumidityBand.NORMAL,
+                bssm.plantshuman.peopleandgreen.recommendation.domain.model.CareLevel.MEDIUM,
+                bssm.plantshuman.peopleandgreen.recommendation.domain.model.ExperienceLevel.BEGINNER,
+                false,
+                PlacementType.LIVING_ROOM
+        );
+    }
+
+    private RecommendPlantsResult result() {
+        return new RecommendPlantsResult(
+                EnvironmentType.ENV_01_SUNNY,
+                List.of(EnvironmentType.ENV_03_BRIGHT_INDIRECT),
+                List.of(
+                        plant("PLT-001", "스투키"),
+                        plant("PLT-002", "몬스테라"),
+                        plant("PLT-003", "산세베리아")
+                )
+        );
+    }
+
+    private PlantRecommendation plant(String plantId, String name) {
+        return new PlantRecommendation(
+                plantId,
+                name,
+                name + "-EN",
+                90,
+                List.of("이유"),
+                List.of("주의"),
+                EnvironmentType.ENV_01_SUNNY,
+                List.of(EnvironmentType.ENV_03_BRIGHT_INDIRECT),
+                AirPurificationLevel.HIGH,
+                PetSafetyLevel.SAFE,
+                DifficultyLevel.EASY,
+                SizeCategory.MEDIUM,
+                List.of(PlacementType.LIVING_ROOM),
+                "설명"
+        );
+    }
+
+    private static final class RecordingRecommendationHistoryCommandPort implements RecommendationHistoryCommandPort {
+
+        private RecommendationHistoryDraft savedDraft;
+
+        @Override
+        public Long save(RecommendationHistoryDraft draft) {
+            this.savedDraft = draft;
+            return 55L;
+        }
+
+        @Override
+        public void delete(Long userId, Long historyId) {
+        }
+    }
+}

--- a/src/test/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/in/web/RecommendationHistoryControllerTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/in/web/RecommendationHistoryControllerTest.java
@@ -1,0 +1,107 @@
+package bssm.plantshuman.peopleandgreen.recommendationhistory.adapter.in.web;
+
+import bssm.plantshuman.peopleandgreen.auth.adapter.out.security.AuthenticatedUser;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsCommand;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsResult;
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.DeleteRecommendationHistoryUseCase;
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.GetRecommendationHistoryUseCase;
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.GetRecommendationHistoriesUseCase;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistory;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistoryCursorPage;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistorySummary;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RecommendationHistoryControllerTest {
+
+    @Test
+    void returnsHistoryPageForAuthenticatedUser() {
+        RecommendationHistoryController controller = new RecommendationHistoryController(
+                (userId, cursor, size) -> new RecommendationHistoryCursorPage(
+                        List.of(new RecommendationHistorySummary(10L, "햇빛이 잘드는 공간", "스투키, 몬스테라", Instant.parse("2026-04-14T10:00:00Z"))),
+                        "10",
+                        false
+                ),
+                (userId, historyId) -> history(historyId),
+                (userId, historyId) -> {}
+        );
+
+        ResponseEntity<RecommendationHistoryPageResponse> response = controller.getHistories(new AuthenticatedUser(1L), null, 20);
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(10L, response.getBody().items().getFirst().historyId());
+    }
+
+    @Test
+    void returnsHistoryDetailForAuthenticatedUser() {
+        RecommendationHistoryController controller = new RecommendationHistoryController(
+                (userId, cursor, size) -> new RecommendationHistoryCursorPage(List.of(), null, false),
+                (userId, historyId) -> history(historyId),
+                (userId, historyId) -> {}
+        );
+
+        ResponseEntity<RecommendationHistoryDetailResponse> response = controller.getHistory(new AuthenticatedUser(1L), 10L);
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(10L, response.getBody().historyId());
+        assertEquals("햇빛이 잘드는 공간", response.getBody().title());
+    }
+
+    @Test
+    void deletesHistoryForAuthenticatedUser() {
+        RecordingDeleteRecommendationHistoryUseCase useCase = new RecordingDeleteRecommendationHistoryUseCase();
+        RecommendationHistoryController controller = new RecommendationHistoryController(
+                (userId, cursor, size) -> new RecommendationHistoryCursorPage(List.of(), null, false),
+                (userId, historyId) -> history(historyId),
+                useCase
+        );
+
+        ResponseEntity<Void> response = controller.deleteHistory(new AuthenticatedUser(1L), 10L);
+
+        assertEquals(204, response.getStatusCode().value());
+        assertEquals(1L, useCase.userId);
+        assertEquals(10L, useCase.historyId);
+    }
+
+    private static RecommendationHistory history(Long historyId) {
+        return new RecommendationHistory(
+                historyId,
+                1L,
+                "햇빛이 잘드는 공간",
+                "스투키, 몬스테라",
+                new RecommendPlantsCommand(
+                        bssm.plantshuman.peopleandgreen.recommendation.domain.model.SunlightLevel.HIGH,
+                        bssm.plantshuman.peopleandgreen.recommendation.domain.model.VentilationLevel.NORMAL,
+                        bssm.plantshuman.peopleandgreen.recommendation.domain.model.TemperatureBand.NORMAL,
+                        bssm.plantshuman.peopleandgreen.recommendation.domain.model.HumidityBand.NORMAL,
+                        bssm.plantshuman.peopleandgreen.recommendation.domain.model.CareLevel.MEDIUM,
+                        bssm.plantshuman.peopleandgreen.recommendation.domain.model.ExperienceLevel.BEGINNER,
+                        false,
+                        bssm.plantshuman.peopleandgreen.recommendation.domain.model.PlacementType.LIVING_ROOM
+                ),
+                new RecommendPlantsResult(
+                        bssm.plantshuman.peopleandgreen.recommendation.domain.model.EnvironmentType.ENV_01_SUNNY,
+                        List.of(),
+                        List.of()
+                ),
+                Instant.parse("2026-04-14T10:00:00Z")
+        );
+    }
+
+    private static final class RecordingDeleteRecommendationHistoryUseCase implements DeleteRecommendationHistoryUseCase {
+
+        private Long userId;
+        private Long historyId;
+
+        @Override
+        public void delete(Long userId, Long historyId) {
+            this.userId = userId;
+            this.historyId = historyId;
+        }
+    }
+}

--- a/src/test/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/in/web/RecommendationHistoryControllerTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/recommendationhistory/adapter/in/web/RecommendationHistoryControllerTest.java
@@ -24,7 +24,7 @@ class RecommendationHistoryControllerTest {
         RecommendationHistoryController controller = new RecommendationHistoryController(
                 (userId, cursor, size) -> new RecommendationHistoryCursorPage(
                         List.of(new RecommendationHistorySummary(10L, "햇빛이 잘드는 공간", "스투키, 몬스테라", Instant.parse("2026-04-14T10:00:00Z"))),
-                        "10",
+                        10L,
                         false
                 ),
                 (userId, historyId) -> history(historyId),
@@ -35,6 +35,7 @@ class RecommendationHistoryControllerTest {
 
         assertEquals(200, response.getStatusCode().value());
         assertEquals(10L, response.getBody().items().getFirst().historyId());
+        assertEquals(10L, response.getBody().nextCursor());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add recommendation history storage, listing, detail lookup, and deletion APIs
- Persist recommendation request/result snapshots with cursor pagination
- Save recommendation results as history and return history metadata from recommendation responses

## Test Plan
- [x] ./gradlew test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 식물 추천 결과를 자동으로 저장하여 사용자 기록으로 관리합니다.
  * 과거 추천 내역을 조회(목록·상세), 페이징으로 나열하고 삭제할 수 있습니다.
  * 추천 응답에 기록 ID(historyId)와 저장 여부(saved) 정보를 포함합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->