### PR TITLE
fix: Google 로그인 중복 레코드 생성 오류 수정

### DIFF
--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/UserPersistenceAdapter.java
@@ -23,20 +23,17 @@ public class UserPersistenceAdapter implements UserAccountPort {
     @Override
     @Transactional
     public AppUser upsertGoogleUser(GoogleUserInfo userInfo) {
-        AppUserEntity entity = appUserRepository.findByOauthProviderAndOauthProviderUserId(OAuthProvider.GOOGLE, userInfo.providerUserId())
-                .map(existing -> {
-                    existing.updateGoogleProfile(userInfo.email(), userInfo.profileImageUrl());
-                    return existing;
-                })
-                .orElseGet(() -> new AppUserEntity(
-                        OAuthProvider.GOOGLE,
-                        userInfo.providerUserId(),
-                        userInfo.email(),
-                        userInfo.name(),
-                        userInfo.profileImageUrl()
-                ));
+        appUserRepository.upsertOAuthUser(
+                OAuthProvider.GOOGLE.name(),
+                userInfo.providerUserId(),
+                userInfo.email(),
+                userInfo.name(),
+                userInfo.profileImageUrl()
+        );
 
-        return toDomain(appUserRepository.save(entity));
+        return appUserRepository.findByOauthProviderAndOauthProviderUserId(OAuthProvider.GOOGLE, userInfo.providerUserId())
+                .map(this::toDomain)
+                .orElseThrow(() -> new IllegalStateException("Failed to load upserted Google user"));
     }
 
     @Override

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/repository/AppUserRepository.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/repository/AppUserRepository.java
@@ -2,11 +2,44 @@ package bssm.plantshuman.peopleandgreen.auth.adapter.out.persistence.repository;
 
 import bssm.plantshuman.peopleandgreen.auth.adapter.out.persistence.entity.AppUserEntity;
 import bssm.plantshuman.peopleandgreen.auth.domain.model.OAuthProvider;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 public interface AppUserRepository extends JpaRepository<AppUserEntity, Long> {
 
     Optional<AppUserEntity> findByOauthProviderAndOauthProviderUserId(OAuthProvider oauthProvider, String oauthProviderUserId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    @Query(value = """
+            INSERT INTO app_user (
+                oauth_provider,
+                oauth_provider_user_id,
+                email,
+                name,
+                profile_image_url
+            )
+            VALUES (
+                :oauthProvider,
+                :oauthProviderUserId,
+                :email,
+                :name,
+                :profileImageUrl
+            )
+            ON DUPLICATE KEY UPDATE
+                email = VALUES(email),
+                profile_image_url = VALUES(profile_image_url)
+            """, nativeQuery = true)
+    void upsertOAuthUser(
+            @Param("oauthProvider") String oauthProvider,
+            @Param("oauthProviderUserId") String oauthProviderUserId,
+            @Param("email") String email,
+            @Param("name") String name,
+            @Param("profileImageUrl") String profileImageUrl
+    );
 }

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/security/JwtTokenProvider.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/security/JwtTokenProvider.java
@@ -11,6 +11,7 @@ import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Date;
+import java.util.UUID;
 
 @Component
 public class JwtTokenProvider implements IssueJwtPort {
@@ -53,6 +54,7 @@ public class JwtTokenProvider implements IssueJwtPort {
     public String issueGoogleState(String redirectUri) {
         Instant now = Instant.now();
         return Jwts.builder()
+                .id(UUID.randomUUID().toString())
                 .issuer(properties.issuer())
                 .subject("google-oauth-state")
                 .claim(TOKEN_TYPE, GOOGLE_STATE)
@@ -91,6 +93,7 @@ public class JwtTokenProvider implements IssueJwtPort {
     private String issueToken(Long userId, String tokenType, long validitySeconds) {
         Instant now = Instant.now();
         return Jwts.builder()
+                .id(UUID.randomUUID().toString())
                 .issuer(properties.issuer())
                 .subject(String.valueOf(userId))
                 .claim(TOKEN_TYPE, tokenType)

--- a/src/test/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/AppUserRepositoryIntegrationTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/AppUserRepositoryIntegrationTest.java
@@ -1,0 +1,52 @@
+package bssm.plantshuman.peopleandgreen.auth.adapter.out.persistence;
+
+import bssm.plantshuman.peopleandgreen.auth.adapter.out.persistence.entity.AppUserEntity;
+import bssm.plantshuman.peopleandgreen.auth.adapter.out.persistence.repository.AppUserRepository;
+import bssm.plantshuman.peopleandgreen.auth.domain.model.OAuthProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:authdb;MODE=MySQL;DB_CLOSE_DELAY=-1",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect"
+})
+class AppUserRepositoryIntegrationTest {
+
+    @Autowired
+    private AppUserRepository appUserRepository;
+
+    @Test
+    void upsertsExistingOAuthUserWithoutCreatingDuplicateUser() {
+        appUserRepository.upsertOAuthUser(
+                OAuthProvider.GOOGLE.name(),
+                "google-user-id",
+                "before@example.com",
+                "before",
+                "https://example.com/before.png"
+        );
+        appUserRepository.upsertOAuthUser(
+                OAuthProvider.GOOGLE.name(),
+                "google-user-id",
+                "after@example.com",
+                "after",
+                "https://example.com/after.png"
+        );
+
+        AppUserEntity user = appUserRepository.findByOauthProviderAndOauthProviderUserId(
+                OAuthProvider.GOOGLE,
+                "google-user-id"
+        ).orElseThrow();
+
+        assertEquals(1L, appUserRepository.count());
+        assertEquals("after@example.com", user.getEmail());
+        assertEquals("before", user.getName());
+        assertEquals("https://example.com/after.png", user.getProfileImageUrl());
+    }
+}

--- a/src/test/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/security/JwtTokenProviderTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/security/JwtTokenProviderTest.java
@@ -35,6 +35,14 @@ class JwtTokenProviderTest {
     }
 
     @Test
+    void issuesUniqueRefreshTokensForRepeatedRequests() {
+        String firstRefreshToken = tokenProvider.issueRefreshToken(1L);
+        String secondRefreshToken = tokenProvider.issueRefreshToken(1L);
+
+        assertFalse(firstRefreshToken.equals(secondRefreshToken));
+    }
+
+    @Test
     void validatesIssuedGoogleStateAgainstRedirectUri() {
         String state = tokenProvider.issueGoogleState("http://localhost:3000/auth/google/callback");
 


### PR DESCRIPTION
## 요약
- JWT 발급 시 `jti`를 추가해 refresh token이 반복 발급되어도 token hash가 중복되지 않도록 수정했습니다.
- Google 유저 저장 로직을 MySQL `ON DUPLICATE KEY UPDATE` 기반 upsert로 변경해 OAuth identity 중복 insert 충돌을 방지했습니다.
- 기존 사용자가 다시 로그인할 때 `name`은 유지하고 `email`, `profileImageUrl`만 갱신하도록 했습니다.

## 테스트
- [x] `./gradlew test --tests bssm.plantshuman.peopleandgreen.auth.adapter.out.security.JwtTokenProviderTest --tests bssm.plantshuman.peopleandgreen.auth.adapter.out.persistence.AppUserRepositoryIntegrationTest`
- [x] `./gradlew test`

Closes #33