### PR TITLE
Flyway 자동 마이그레이션 활성화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
     implementation 'org.flywaydb:flyway-core'
+    implementation 'org.springframework.boot:spring-boot-flyway'
     implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.7'

--- a/src/test/java/bssm/plantshuman/peopleandgreen/infrastructure/config/RecommendationCatalogSeedMigrationTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/infrastructure/config/RecommendationCatalogSeedMigrationTest.java
@@ -1,13 +1,9 @@
 package bssm.plantshuman.peopleandgreen.infrastructure.config;
 
-import org.flywaydb.core.Flyway;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-
-import javax.sql.DataSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -17,25 +13,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
         "spring.datasource.password=",
         "spring.datasource.driver-class-name=org.h2.Driver",
         "spring.jpa.hibernate.ddl-auto=none",
-        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
-        "spring.flyway.enabled=false"
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect"
 })
 class RecommendationCatalogSeedMigrationTest {
 
     @Autowired
-    private DataSource dataSource;
-
-    @Autowired
     private JdbcTemplate jdbcTemplate;
-
-    @BeforeEach
-    void migrate() {
-        Flyway.configure()
-                .dataSource(dataSource)
-                .locations("classpath:db/migration")
-                .load()
-                .migrate();
-    }
 
     @Test
     void seedsRecommendationCatalogTables() {


### PR DESCRIPTION
## 요약

- Spring Boot 4에서 Flyway 자동 설정이 로드되도록 `spring-boot-flyway` 의존성을 추가했습니다.
- 추천 카탈로그 seed migration 테스트가 수동 Flyway 호출 없이 앱 시작 시 자동 migration을 검증하도록 수정했습니다.

## 원인

배포 이미지에는 `V3__seed_recommendation_catalog.sql`이 포함되어 있었지만, 앱 로그에 Flyway 실행 로그가 없었습니다. Boot 4 환경에서 Flyway Core만으로는 자동 설정이 로드되지 않아 migration이 실행되지 않았습니다.

## 테스트

- [x] `./gradlew test --tests bssm.plantshuman.peopleandgreen.infrastructure.config.RecommendationCatalogSeedMigrationTest --rerun-tasks`
- [x] `./gradlew test --rerun-tasks`

Closes #37
