### PR TITLE
feat: 로그인 응답에 첫 로그인 여부 추가

### DIFF
--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/dto/response/AuthTokenResponse.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/dto/response/AuthTokenResponse.java
@@ -12,12 +12,14 @@ import bssm.plantshuman.peopleandgreen.auth.domain.model.PreparedGoogleAuthoriza
 public record AuthTokenResponse(
         String accessToken,
         long expiresIn,
+        boolean firstLogin,
         UserResponse user
 ) {
     public static AuthTokenResponse from(AuthTokens tokens) {
         return new AuthTokenResponse(
                 tokens.accessToken(),
                 tokens.expiresIn(),
+                tokens.firstLogin(),
                 tokens.user() == null ? null : UserResponse.from(tokens.user())
         );
     }

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/UserPersistenceAdapter.java
@@ -4,6 +4,7 @@ import bssm.plantshuman.peopleandgreen.auth.adapter.out.persistence.entity.AppUs
 import bssm.plantshuman.peopleandgreen.auth.adapter.out.persistence.repository.AppUserRepository;
 import bssm.plantshuman.peopleandgreen.auth.application.port.out.UserAccountPort;
 import bssm.plantshuman.peopleandgreen.auth.domain.model.AppUser;
+import bssm.plantshuman.peopleandgreen.auth.domain.model.AppUserUpsertResult;
 import bssm.plantshuman.peopleandgreen.auth.domain.model.GoogleUserInfo;
 import bssm.plantshuman.peopleandgreen.auth.domain.model.OAuthProvider;
 import org.springframework.stereotype.Component;
@@ -22,18 +23,20 @@ public class UserPersistenceAdapter implements UserAccountPort {
 
     @Override
     @Transactional
-    public AppUser upsertGoogleUser(GoogleUserInfo userInfo) {
-        appUserRepository.upsertOAuthUser(
+    public AppUserUpsertResult upsertGoogleUser(GoogleUserInfo userInfo) {
+        int affectedRows = appUserRepository.upsertOAuthUser(
                 OAuthProvider.GOOGLE.name(),
                 userInfo.providerUserId(),
                 userInfo.email(),
                 userInfo.name(),
                 userInfo.profileImageUrl()
         );
+        boolean created = affectedRows == 1;
 
-        return appUserRepository.findByOauthProviderAndOauthProviderUserId(OAuthProvider.GOOGLE, userInfo.providerUserId())
+        AppUser user = appUserRepository.findByOauthProviderAndOauthProviderUserId(OAuthProvider.GOOGLE, userInfo.providerUserId())
                 .map(this::toDomain)
                 .orElseThrow(() -> new IllegalStateException("Failed to load upserted Google user"));
+        return new AppUserUpsertResult(user, created);
     }
 
     @Override

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/repository/AppUserRepository.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/repository/AppUserRepository.java
@@ -35,7 +35,7 @@ public interface AppUserRepository extends JpaRepository<AppUserEntity, Long> {
                 email = VALUES(email),
                 profile_image_url = VALUES(profile_image_url)
             """, nativeQuery = true)
-    void upsertOAuthUser(
+    int upsertOAuthUser(
             @Param("oauthProvider") String oauthProvider,
             @Param("oauthProviderUserId") String oauthProviderUserId,
             @Param("email") String email,

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/application/port/out/UserAccountPort.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/application/port/out/UserAccountPort.java
@@ -1,13 +1,14 @@
 package bssm.plantshuman.peopleandgreen.auth.application.port.out;
 
 import bssm.plantshuman.peopleandgreen.auth.domain.model.AppUser;
+import bssm.plantshuman.peopleandgreen.auth.domain.model.AppUserUpsertResult;
 import bssm.plantshuman.peopleandgreen.auth.domain.model.GoogleUserInfo;
 
 import java.util.Optional;
 
 public interface UserAccountPort {
 
-    AppUser upsertGoogleUser(GoogleUserInfo userInfo);
+    AppUserUpsertResult upsertGoogleUser(GoogleUserInfo userInfo);
 
     Optional<AppUser> findById(Long userId);
 

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/application/service/LoginWithGoogleService.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/application/service/LoginWithGoogleService.java
@@ -8,6 +8,7 @@ import bssm.plantshuman.peopleandgreen.auth.application.port.out.RefreshTokenHas
 import bssm.plantshuman.peopleandgreen.auth.application.port.out.RefreshTokenStorePort;
 import bssm.plantshuman.peopleandgreen.auth.application.port.out.UserAccountPort;
 import bssm.plantshuman.peopleandgreen.auth.domain.model.AppUser;
+import bssm.plantshuman.peopleandgreen.auth.domain.model.AppUserUpsertResult;
 import bssm.plantshuman.peopleandgreen.auth.domain.model.AuthTokens;
 import bssm.plantshuman.peopleandgreen.auth.domain.model.GoogleUserInfo;
 import lombok.RequiredArgsConstructor;
@@ -32,12 +33,12 @@ public class LoginWithGoogleService implements LoginWithGoogleUseCase {
         issueJwtPort.validateGoogleState(state, redirectUri);
 
         GoogleUserInfo googleUserInfo = exchangeGoogleAuthCodePort.exchange(authorizationCode, redirectUri);
-        AppUser user = userAccountPort.upsertGoogleUser(googleUserInfo);
+        AppUserUpsertResult upsertResult = userAccountPort.upsertGoogleUser(googleUserInfo);
 
-        return issueTokens(user);
+        return issueTokens(upsertResult.user(), upsertResult.created());
     }
 
-    AuthTokens issueTokens(AppUser user) {
+    AuthTokens issueTokens(AppUser user, boolean firstLogin) {
         String accessToken = issueJwtPort.issueAccessToken(user.id());
         String refreshToken = issueJwtPort.issueRefreshToken(user.id());
         refreshTokenStorePort.save(
@@ -45,6 +46,13 @@ public class LoginWithGoogleService implements LoginWithGoogleUseCase {
                 refreshTokenHashPort.hash(refreshToken),
                 Instant.now().plusSeconds(issueJwtPort.getRefreshTokenValiditySeconds())
         );
-        return new AuthTokens(accessToken, refreshToken, issueJwtPort.getAccessTokenValiditySeconds(), issueJwtPort.getRefreshTokenValiditySeconds(), user);
+        return new AuthTokens(
+                accessToken,
+                refreshToken,
+                issueJwtPort.getAccessTokenValiditySeconds(),
+                issueJwtPort.getRefreshTokenValiditySeconds(),
+                firstLogin,
+                user
+        );
     }
 }

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/application/service/RefreshAccessTokenService.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/application/service/RefreshAccessTokenService.java
@@ -66,6 +66,7 @@ public class RefreshAccessTokenService implements RefreshAccessTokenUseCase {
                 newRefreshToken,
                 issueJwtPort.getAccessTokenValiditySeconds(),
                 issueJwtPort.getRefreshTokenValiditySeconds(),
+                false,
                 user
         );
     }

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/domain/model/AppUserUpsertResult.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/domain/model/AppUserUpsertResult.java
@@ -1,0 +1,7 @@
+package bssm.plantshuman.peopleandgreen.auth.domain.model;
+
+public record AppUserUpsertResult(
+        AppUser user,
+        boolean created
+) {
+}

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/domain/model/AuthTokens.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/domain/model/AuthTokens.java
@@ -5,6 +5,7 @@ public record AuthTokens(
         String refreshToken,
         long expiresIn,
         long refreshExpiresIn,
+        boolean firstLogin,
         AppUser user
 ) {
 }

--- a/src/test/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/AuthControllerTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/auth/adapter/in/web/AuthControllerTest.java
@@ -43,6 +43,7 @@ class AuthControllerTest {
 
         assertEquals(200, response.getStatusCode().value());
         assertEquals("ACCESS_TOKEN", response.getBody().accessToken());
+        assertEquals(true, response.getBody().firstLogin());
         assertEquals(1L, response.getBody().user().id());
         String setCookie = httpResponse.getHeader("Set-Cookie");
         assertNotNull(setCookie);
@@ -113,6 +114,7 @@ class AuthControllerTest {
                 "REFRESH_TOKEN",
                 900,
                 1209600,
+                true,
                 new AppUser(1L, OAuthProvider.GOOGLE, "google-123", "jjm@example.com", "jjm", "https://image")
         );
     }

--- a/src/test/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/AppUserRepositoryIntegrationTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/AppUserRepositoryIntegrationTest.java
@@ -2,7 +2,10 @@ package bssm.plantshuman.peopleandgreen.auth.adapter.out.persistence;
 
 import bssm.plantshuman.peopleandgreen.auth.adapter.out.persistence.entity.AppUserEntity;
 import bssm.plantshuman.peopleandgreen.auth.adapter.out.persistence.repository.AppUserRepository;
+import bssm.plantshuman.peopleandgreen.auth.domain.model.AppUserUpsertResult;
+import bssm.plantshuman.peopleandgreen.auth.domain.model.GoogleUserInfo;
 import bssm.plantshuman.peopleandgreen.auth.domain.model.OAuthProvider;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,6 +24,27 @@ class AppUserRepositoryIntegrationTest {
 
     @Autowired
     private AppUserRepository appUserRepository;
+
+    @BeforeEach
+    void setUp() {
+        appUserRepository.deleteAll();
+    }
+
+    @Test
+    void userPersistenceAdapterReportsWhetherGoogleUserWasCreated() {
+        UserPersistenceAdapter adapter = new UserPersistenceAdapter(appUserRepository);
+
+        AppUserUpsertResult firstLogin = adapter.upsertGoogleUser(
+                new GoogleUserInfo("adapter-user-id", "first@example.com", "first", "https://example.com/first.png")
+        );
+        AppUserUpsertResult nextLogin = adapter.upsertGoogleUser(
+                new GoogleUserInfo("adapter-user-id", "next@example.com", "next", "https://example.com/next.png")
+        );
+
+        assertEquals(true, firstLogin.created());
+        assertEquals(false, nextLogin.created());
+        assertEquals(firstLogin.user().id(), nextLogin.user().id());
+    }
 
     @Test
     void upsertsExistingOAuthUserWithoutCreatingDuplicateUser() {

--- a/src/test/java/bssm/plantshuman/peopleandgreen/auth/application/service/AuthServiceTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/auth/application/service/AuthServiceTest.java
@@ -7,6 +7,7 @@ import bssm.plantshuman.peopleandgreen.auth.application.port.out.RefreshTokenHas
 import bssm.plantshuman.peopleandgreen.auth.application.port.out.RefreshTokenStorePort;
 import bssm.plantshuman.peopleandgreen.auth.application.port.out.UserAccountPort;
 import bssm.plantshuman.peopleandgreen.auth.domain.model.AppUser;
+import bssm.plantshuman.peopleandgreen.auth.domain.model.AppUserUpsertResult;
 import bssm.plantshuman.peopleandgreen.auth.domain.model.GoogleUserInfo;
 import bssm.plantshuman.peopleandgreen.auth.domain.model.OAuthProvider;
 import bssm.plantshuman.peopleandgreen.auth.domain.model.PreparedGoogleAuthorization;
@@ -63,6 +64,7 @@ class AuthServiceTest {
         assertEquals("ACCESS_TOKEN", tokens.accessToken());
         assertEquals("REFRESH_TOKEN", tokens.refreshToken());
         assertEquals(900, tokens.expiresIn());
+        assertEquals(true, tokens.firstLogin());
         assertEquals(1L, tokens.user().id());
         assertEquals(1L, refreshTokenStorePort.savedUserId);
         assertEquals("HASHED_REFRESH_TOKEN", refreshTokenStorePort.savedTokenHash);
@@ -85,6 +87,7 @@ class AuthServiceTest {
         var tokens = service.login("AUTH_CODE", "STATE_TOKEN", "http://localhost:3000/auth/google/callback");
 
         assertEquals("chosenName", tokens.user().name());
+        assertEquals(false, tokens.firstLogin());
         assertEquals("after@example.com", tokens.user().email());
         assertEquals("https://new-image", tokens.user().profileImageUrl());
     }
@@ -255,8 +258,11 @@ class AuthServiceTest {
     private static final class StubUserAccountPort implements UserAccountPort {
 
         @Override
-        public AppUser upsertGoogleUser(GoogleUserInfo userInfo) {
-            return new AppUser(1L, OAuthProvider.GOOGLE, userInfo.providerUserId(), userInfo.email(), userInfo.name(), userInfo.profileImageUrl());
+        public AppUserUpsertResult upsertGoogleUser(GoogleUserInfo userInfo) {
+            return new AppUserUpsertResult(
+                    new AppUser(1L, OAuthProvider.GOOGLE, userInfo.providerUserId(), userInfo.email(), userInfo.name(), userInfo.profileImageUrl()),
+                    true
+            );
         }
 
         @Override
@@ -283,7 +289,7 @@ class AuthServiceTest {
         }
 
         @Override
-        public AppUser upsertGoogleUser(GoogleUserInfo userInfo) {
+        public AppUserUpsertResult upsertGoogleUser(GoogleUserInfo userInfo) {
             if (existingUser != null
                     && existingUser.oauthProvider() == OAuthProvider.GOOGLE
                     && existingUser.oauthProviderUserId().equals(userInfo.providerUserId())) {
@@ -295,11 +301,11 @@ class AuthServiceTest {
                         existingUser.name(),
                         userInfo.profileImageUrl()
                 );
-                return existingUser;
+                return new AppUserUpsertResult(existingUser, false);
             }
 
             existingUser = new AppUser(1L, OAuthProvider.GOOGLE, userInfo.providerUserId(), userInfo.email(), userInfo.name(), userInfo.profileImageUrl());
-            return existingUser;
+            return new AppUserUpsertResult(existingUser, true);
         }
 
         @Override


### PR DESCRIPTION
## Summary
- 로그인 응답에 `firstLogin` boolean 필드를 추가했습니다.
- Google OAuth 유저 upsert 결과로 신규 생성 여부를 판별해 로그인 토큰 응답에 전달합니다.
- refresh token 갱신 응답은 첫 로그인 이벤트가 아니므로 `firstLogin=false`로 유지합니다.

## Test Plan
- [x] `./gradlew test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Google 로그인 시 첫 로그인 여부를 구분하여 추적할 수 있도록 개선했습니다. 인증 응답에 첫 로그인 정보가 포함됩니다.

* **Tests**
  * 첫 로그인 여부 추적 기능에 대한 테스트 케이스를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Person-Green/Backend-Server/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->