### PR TITLE
fix: 첫 로그인 여부 판별 수정

### DIFF
--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/UserPersistenceAdapter.java
@@ -24,14 +24,18 @@ public class UserPersistenceAdapter implements UserAccountPort {
     @Override
     @Transactional
     public AppUserUpsertResult upsertGoogleUser(GoogleUserInfo userInfo) {
-        int affectedRows = appUserRepository.upsertOAuthUser(
+        boolean created = appUserRepository.findByOauthProviderAndOauthProviderUserId(
+                OAuthProvider.GOOGLE,
+                userInfo.providerUserId()
+        ).isEmpty();
+
+        appUserRepository.upsertOAuthUser(
                 OAuthProvider.GOOGLE.name(),
                 userInfo.providerUserId(),
                 userInfo.email(),
                 userInfo.name(),
                 userInfo.profileImageUrl()
         );
-        boolean created = affectedRows == 1;
 
         AppUser user = appUserRepository.findByOauthProviderAndOauthProviderUserId(OAuthProvider.GOOGLE, userInfo.providerUserId())
                 .map(this::toDomain)

--- a/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/repository/AppUserRepository.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/repository/AppUserRepository.java
@@ -35,7 +35,7 @@ public interface AppUserRepository extends JpaRepository<AppUserEntity, Long> {
                 email = VALUES(email),
                 profile_image_url = VALUES(profile_image_url)
             """, nativeQuery = true)
-    int upsertOAuthUser(
+    void upsertOAuthUser(
             @Param("oauthProvider") String oauthProvider,
             @Param("oauthProviderUserId") String oauthProviderUserId,
             @Param("email") String email,

--- a/src/test/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/AppUserRepositoryIntegrationTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/AppUserRepositoryIntegrationTest.java
@@ -47,6 +47,23 @@ class AppUserRepositoryIntegrationTest {
     }
 
     @Test
+    void userPersistenceAdapterReportsExistingGoogleUserEvenWhenProfileIsUnchanged() {
+        UserPersistenceAdapter adapter = new UserPersistenceAdapter(appUserRepository);
+        GoogleUserInfo userInfo = new GoogleUserInfo(
+                "unchanged-user-id",
+                "same@example.com",
+                "same",
+                "https://example.com/same.png"
+        );
+
+        AppUserUpsertResult firstLogin = adapter.upsertGoogleUser(userInfo);
+        AppUserUpsertResult nextLogin = adapter.upsertGoogleUser(userInfo);
+
+        assertEquals(true, firstLogin.created());
+        assertEquals(false, nextLogin.created());
+    }
+
+    @Test
     void upsertsExistingOAuthUserWithoutCreatingDuplicateUser() {
         appUserRepository.upsertOAuthUser(
                 OAuthProvider.GOOGLE.name(),

--- a/src/test/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/UserPersistenceAdapterTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/auth/adapter/out/persistence/UserPersistenceAdapterTest.java
@@ -1,0 +1,42 @@
+package bssm.plantshuman.peopleandgreen.auth.adapter.out.persistence;
+
+import bssm.plantshuman.peopleandgreen.auth.adapter.out.persistence.entity.AppUserEntity;
+import bssm.plantshuman.peopleandgreen.auth.adapter.out.persistence.repository.AppUserRepository;
+import bssm.plantshuman.peopleandgreen.auth.domain.model.AppUserUpsertResult;
+import bssm.plantshuman.peopleandgreen.auth.domain.model.GoogleUserInfo;
+import bssm.plantshuman.peopleandgreen.auth.domain.model.OAuthProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class UserPersistenceAdapterTest {
+
+    @Test
+    void reportsExistingUserEvenWhenUpsertAffectedRowsLooksLikeInsert() {
+        AppUserRepository repository = mock(AppUserRepository.class);
+        UserPersistenceAdapter adapter = new UserPersistenceAdapter(repository);
+        GoogleUserInfo userInfo = new GoogleUserInfo(
+                "google-user-id",
+                "jjm@example.com",
+                "jjm",
+                "https://example.com/profile.png"
+        );
+        AppUserEntity existingUser = new AppUserEntity(
+                OAuthProvider.GOOGLE,
+                userInfo.providerUserId(),
+                userInfo.email(),
+                userInfo.name(),
+                userInfo.profileImageUrl()
+        );
+        when(repository.findByOauthProviderAndOauthProviderUserId(OAuthProvider.GOOGLE, userInfo.providerUserId()))
+                .thenReturn(Optional.of(existingUser));
+
+        AppUserUpsertResult result = adapter.upsertGoogleUser(userInfo);
+
+        assertEquals(false, result.created());
+    }
+}


### PR DESCRIPTION
## Summary
- `ON DUPLICATE KEY UPDATE` affected row 값에 의존하던 첫 로그인 판별을 제거했습니다.
- Google OAuth identity 존재 여부를 upsert 전에 확인해 기존 유저는 `firstLogin=false`로 응답합니다.
- 기존 유저 업데이트와 동일 프로필 재로그인 회귀 테스트를 추가했습니다.

## Test Plan
- [x] `./gradlew test`