### PR TITLE
추천 히스토리 좋아요 메타데이터 최신화

### DIFF
--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/GetRecommendationHistoryService.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/GetRecommendationHistoryService.java
@@ -1,8 +1,11 @@
 package bssm.plantshuman.peopleandgreen.recommendation.application.service;
 
 import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.GetRecommendationHistoryUseCase;
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.out.LoadRecommendationFavoriteMetadataPort;
 import bssm.plantshuman.peopleandgreen.recommendation.application.port.out.RecommendationHistoryQueryPort;
 import bssm.plantshuman.peopleandgreen.recommendation.domain.exception.RecommendationHistoryNotFoundException;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsResult;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationFavoriteMetadata;
 import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,10 +15,23 @@ import org.springframework.stereotype.Service;
 public class GetRecommendationHistoryService implements GetRecommendationHistoryUseCase {
 
     private final RecommendationHistoryQueryPort recommendationHistoryQueryPort;
+    private final LoadRecommendationFavoriteMetadataPort loadRecommendationFavoriteMetadataPort;
 
     @Override
     public RecommendationHistory getHistory(Long userId, Long historyId) {
-        return recommendationHistoryQueryPort.getHistory(userId, historyId)
+        RecommendationHistory history = recommendationHistoryQueryPort.getHistory(userId, historyId)
                 .orElseThrow(RecommendationHistoryNotFoundException::new);
+        RecommendPlantsResult result = history.resultSnapshot();
+        RecommendationFavoriteMetadata favoriteMetadata = loadRecommendationFavoriteMetadataPort.load(userId, result.plantIds());
+
+        return new RecommendationHistory(
+                history.id(),
+                history.userId(),
+                history.title(),
+                history.plantSummaryText(),
+                history.requestSnapshot(),
+                result.withFavoriteMetadata(favoriteMetadata),
+                history.createdAt()
+        );
     }
 }

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/RecommendPlantsWithHistoryService.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/RecommendPlantsWithHistoryService.java
@@ -5,7 +5,6 @@ import bssm.plantshuman.peopleandgreen.recommendation.application.port.in.Recomm
 import bssm.plantshuman.peopleandgreen.recommendation.application.port.out.LoadRecommendationFavoriteMetadataPort;
 import bssm.plantshuman.peopleandgreen.recommendation.application.port.out.RecommendationHistoryCommandPort;
 import bssm.plantshuman.peopleandgreen.recommendation.domain.model.EnvironmentType;
-import bssm.plantshuman.peopleandgreen.recommendation.domain.model.PlantRecommendation;
 import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsCommand;
 import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsExecutionResult;
 import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsResult;
@@ -13,9 +12,6 @@ import bssm.plantshuman.peopleandgreen.recommendation.domain.model.Recommendatio
 import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistoryDraft;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -33,28 +29,15 @@ public class RecommendPlantsWithHistoryService implements RecommendPlantsWithHis
                 titleFor(result.representativeEnvironment()),
                 summarizePlants(result),
                 command,
-                result
+                result.withoutFavoriteMetadata()
         );
         Long historyId = recommendationHistoryCommandPort.save(draft);
         return new RecommendPlantsExecutionResult(historyId, true, result);
     }
 
     private RecommendPlantsResult withFavoriteMetadata(Long userId, RecommendPlantsResult result) {
-        Set<String> plantIds = result.plants().stream()
-                .map(PlantRecommendation::plantId)
-                .collect(Collectors.toSet());
-        RecommendationFavoriteMetadata favoriteMetadata = loadRecommendationFavoriteMetadataPort.load(userId, plantIds);
-
-        return new RecommendPlantsResult(
-                result.representativeEnvironment(),
-                result.secondaryEnvironmentTags(),
-                result.plants().stream()
-                        .map(plant -> plant.withFavoriteMetadata(
-                                favoriteMetadata.isFavorite(plant.plantId()),
-                                favoriteMetadata.favoriteCount(plant.plantId())
-                        ))
-                        .toList()
-        );
+        RecommendationFavoriteMetadata favoriteMetadata = loadRecommendationFavoriteMetadataPort.load(userId, result.plantIds());
+        return result.withFavoriteMetadata(favoriteMetadata);
     }
 
     private String summarizePlants(RecommendPlantsResult result) {

--- a/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/model/RecommendPlantsResult.java
+++ b/src/main/java/bssm/plantshuman/peopleandgreen/recommendation/domain/model/RecommendPlantsResult.java
@@ -1,10 +1,40 @@
 package bssm.plantshuman.peopleandgreen.recommendation.domain.model;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public record RecommendPlantsResult(
         EnvironmentType representativeEnvironment,
         List<EnvironmentType> secondaryEnvironmentTags,
         List<PlantRecommendation> plants
 ) {
+    public Set<String> plantIds() {
+        return plants.stream()
+                .map(PlantRecommendation::plantId)
+                .collect(Collectors.toSet());
+    }
+
+    public RecommendPlantsResult withFavoriteMetadata(RecommendationFavoriteMetadata favoriteMetadata) {
+        return new RecommendPlantsResult(
+                representativeEnvironment,
+                secondaryEnvironmentTags,
+                plants.stream()
+                        .map(plant -> plant.withFavoriteMetadata(
+                                favoriteMetadata.isFavorite(plant.plantId()),
+                                favoriteMetadata.favoriteCount(plant.plantId())
+                        ))
+                        .toList()
+        );
+    }
+
+    public RecommendPlantsResult withoutFavoriteMetadata() {
+        return new RecommendPlantsResult(
+                representativeEnvironment,
+                secondaryEnvironmentTags,
+                plants.stream()
+                        .map(plant -> plant.withFavoriteMetadata(false, 0L))
+                        .toList()
+        );
+    }
 }

--- a/src/test/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/GetRecommendationHistoryServiceTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/GetRecommendationHistoryServiceTest.java
@@ -1,0 +1,132 @@
+package bssm.plantshuman.peopleandgreen.recommendation.application.service;
+
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.out.LoadRecommendationFavoriteMetadataPort;
+import bssm.plantshuman.peopleandgreen.recommendation.application.port.out.RecommendationHistoryQueryPort;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.AirPurificationLevel;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.CareLevel;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.DifficultyLevel;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.EnvironmentType;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.ExperienceLevel;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.HumidityBand;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.PetSafetyLevel;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.PlacementType;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.PlantRecommendation;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsCommand;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendPlantsResult;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationFavoriteMetadata;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistory;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.RecommendationHistoryCursorPage;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.SizeCategory;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.SunlightLevel;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.TemperatureBand;
+import bssm.plantshuman.peopleandgreen.recommendation.domain.model.VentilationLevel;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GetRecommendationHistoryServiceTest {
+
+    @Test
+    void returnsHistoryWithCurrentFavoriteMetadata() {
+        GetRecommendationHistoryService service = new GetRecommendationHistoryService(
+                new StubRecommendationHistoryQueryPort(),
+                new StubLoadRecommendationFavoriteMetadataPort()
+        );
+
+        RecommendationHistory history = service.getHistory(1L, 10L);
+
+        PlantRecommendation firstPlant = history.resultSnapshot().plants().getFirst();
+        PlantRecommendation secondPlant = history.resultSnapshot().plants().get(1);
+        assertEquals(true, firstPlant.isFavorite());
+        assertEquals(9L, firstPlant.favoriteCount());
+        assertEquals(false, secondPlant.isFavorite());
+        assertEquals(3L, secondPlant.favoriteCount());
+    }
+
+    private static RecommendationHistory history() {
+        return new RecommendationHistory(
+                10L,
+                1L,
+                "햇빛이 잘드는 공간",
+                "스투키, 몬스테라",
+                new RecommendPlantsCommand(
+                        SunlightLevel.HIGH,
+                        VentilationLevel.NORMAL,
+                        TemperatureBand.NORMAL,
+                        HumidityBand.NORMAL,
+                        CareLevel.MEDIUM,
+                        ExperienceLevel.BEGINNER,
+                        false,
+                        PlacementType.LIVING_ROOM
+                ),
+                new RecommendPlantsResult(
+                        EnvironmentType.ENV_01_SUNNY,
+                        List.of(EnvironmentType.ENV_03_BRIGHT_INDIRECT),
+                        List.of(
+                                plant("PLT-001", "스투키", false, 0L),
+                                plant("PLT-002", "몬스테라", true, 20L)
+                        )
+                ),
+                Instant.parse("2026-04-14T10:00:00Z")
+        );
+    }
+
+    private static PlantRecommendation plant(String plantId, String name, boolean isFavorite, long favoriteCount) {
+        return new PlantRecommendation(
+                plantId,
+                name,
+                name + "-EN",
+                null,
+                isFavorite,
+                favoriteCount,
+                90,
+                List.of("이유"),
+                List.of("주의"),
+                EnvironmentType.ENV_01_SUNNY,
+                List.of(EnvironmentType.ENV_03_BRIGHT_INDIRECT),
+                AirPurificationLevel.HIGH,
+                PetSafetyLevel.SAFE,
+                DifficultyLevel.EASY,
+                SizeCategory.MEDIUM,
+                List.of(PlacementType.LIVING_ROOM),
+                "설명"
+        );
+    }
+
+    private static final class StubRecommendationHistoryQueryPort implements RecommendationHistoryQueryPort {
+
+        @Override
+        public RecommendationHistoryCursorPage getHistories(Long userId, Long cursor, int size) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<RecommendationHistory> getHistory(Long userId, Long historyId) {
+            assertEquals(1L, userId);
+            assertEquals(10L, historyId);
+            return Optional.of(history());
+        }
+    }
+
+    private static final class StubLoadRecommendationFavoriteMetadataPort implements LoadRecommendationFavoriteMetadataPort {
+
+        @Override
+        public RecommendationFavoriteMetadata load(Long userId, Set<String> plantIds) {
+            assertEquals(1L, userId);
+            assertEquals(Set.of("PLT-001", "PLT-002"), plantIds);
+            return new RecommendationFavoriteMetadata(
+                    Set.of("PLT-001"),
+                    Map.of(
+                            "PLT-001", 9L,
+                            "PLT-002", 3L
+                    )
+            );
+        }
+    }
+}

--- a/src/test/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/RecommendPlantsWithHistoryServiceTest.java
+++ b/src/test/java/bssm/plantshuman/peopleandgreen/recommendation/application/service/RecommendPlantsWithHistoryServiceTest.java
@@ -45,8 +45,8 @@ class RecommendPlantsWithHistoryServiceTest {
         assertEquals("스투키", executionResult.result().plants().getFirst().plantName());
         assertEquals(true, executionResult.result().plants().getFirst().isFavorite());
         assertEquals(7L, executionResult.result().plants().getFirst().favoriteCount());
-        assertEquals(true, historyCommandPort.savedDraft.resultSnapshot().plants().getFirst().isFavorite());
-        assertEquals(7L, historyCommandPort.savedDraft.resultSnapshot().plants().getFirst().favoriteCount());
+        assertEquals(false, historyCommandPort.savedDraft.resultSnapshot().plants().getFirst().isFavorite());
+        assertEquals(0L, historyCommandPort.savedDraft.resultSnapshot().plants().getFirst().favoriteCount());
     }
 
     private RecommendPlantsCommand command() {


### PR DESCRIPTION
## 요약
- 추천 히스토리 저장 시 좋아요 여부와 좋아요 수를 스냅샷에서 제거했습니다.
- 추천 히스토리 상세 조회 시 저장된 식물 ID 기준으로 최신 좋아요 메타데이터를 다시 적용하도록 변경했습니다.
- 히스토리 조회와 저장 동작을 검증하는 테스트를 추가/수정했습니다.

## 테스트
- ./gradlew test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **리팩토링**
  * 추천 결과의 즐겨찾기 메타데이터 처리 로직을 개선했습니다.
  * 즐겨찾기 메타데이터 적용 방식을 단순화하고 효율성을 높였습니다.

* **테스트**
  * 추천 이력 조회 시 즐겨찾기 메타데이터가 올바르게 반영되는지 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->